### PR TITLE
Fix ChipResolver duplicate chip creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -131,6 +131,21 @@ public class DatalatheClient {
      * @throws IllegalArgumentException if sourceType is not set on the source
      */
     public String createChip(ChipSource source, String chipId) throws IOException {
+        return createChip(source, chipId, null);
+    }
+
+    /**
+     * Creates a chip from a pre-built Source object with optional chip ID and tags.
+     * Tags are applied atomically with chip creation.
+     *
+     * @param source The fully configured source
+     * @param chipId Optional chip ID to use
+     * @param tags   Optional tags to apply atomically with creation
+     * @return The chip ID
+     * @throws IOException              if the API call fails
+     * @throws IllegalArgumentException if sourceType is not set on the source
+     */
+    public String createChip(ChipSource source, String chipId, Map<String, String> tags) throws IOException {
         if (source.getSourceType() == null) {
             throw new IllegalArgumentException("sourceType must be set on the Source");
         }
@@ -139,6 +154,7 @@ public class DatalatheClient {
         request.setSource(source);
         request.setChipId(chipId);
         request.setStorageConfig(source.getStorageConfig());
+        request.setTags(tags);
         CreateChipResponse response = post("/lathe/stage/data", request, CreateChipResponse.class);
         if (response.getError() != null) {
             throw new IOException("Failed to stage data: " + response.getError());

--- a/src/main/java/com/datalathe/client/resolver/ChipResolver.java
+++ b/src/main/java/com/datalathe/client/resolver/ChipResolver.java
@@ -8,8 +8,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.*;
 
 /**
  * Resolves the set of chips needed for a report, creating any that are missing.
@@ -60,13 +59,28 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ChipResolver {
 
     private static final Logger log = LogManager.getLogger(ChipResolver.class);
+    private static final long DEFAULT_TIMEOUT_MINUTES = 10;
 
     private final DatalatheClient client;
+    private final ExecutorService executor;
+    private final long timeoutMinutes;
     private final ConcurrentHashMap<String, CompletableFuture<String>> inflight =
             new ConcurrentHashMap<>();
 
     public ChipResolver(DatalatheClient client) {
+        this(client, Executors.newFixedThreadPool(
+                Math.max(4, Runtime.getRuntime().availableProcessors()),
+                r -> {
+                    Thread t = new Thread(r, "chip-resolver");
+                    t.setDaemon(true);
+                    return t;
+                }), DEFAULT_TIMEOUT_MINUTES);
+    }
+
+    public ChipResolver(DatalatheClient client, ExecutorService executor, long timeoutMinutes) {
         this.client = client;
+        this.executor = executor;
+        this.timeoutMinutes = timeoutMinutes;
     }
 
     /**
@@ -152,6 +166,7 @@ public class ChipResolver {
         List<String> existingUnpartitionedIds = new ArrayList<>();
         List<String> existingPartitionedIds = new ArrayList<>();
         Set<String> pvSet = new HashSet<>(partitionValues);
+        String keyPrefix = tagKey + ":" + tagValue + "|";
 
         if (existing.getChips() != null) {
             for (var chip : existing.getChips()) {
@@ -161,10 +176,13 @@ public class ChipResolver {
                         && chip.getChipId().equals(chip.getSubChipId())
                         && existingUnpartitionedTables.add(table)) {
                     existingUnpartitionedIds.add(chip.getChipId());
+                    // Chip is now searchable — evict from inflight cache
+                    inflight.remove(keyPrefix + table + "|" + null);
                 } else if (partitionedTables.contains(table)
                         && pvSet.contains(chip.getPartitionValue())
                         && existingPartitionedKeys.add(table + "|" + chip.getPartitionValue())) {
                     existingPartitionedIds.add(chip.getChipId());
+                    inflight.remove(keyPrefix + table + "|" + chip.getPartitionValue());
                 }
             }
         }
@@ -241,16 +259,17 @@ public class ChipResolver {
                     .supplyAsync(() -> {
                         try {
                             ChipSource source = factory.buildSource(table, partitionValue);
-                            String chipId = client.createChip(source);
-                            client.addChipTags(chipId, Map.of(tagKey, tagValue));
-                            return chipId;
+                            return client.createChip(source, null, Map.of(tagKey, tagValue));
                         } catch (IOException e) {
                             log.error("Chip creation failed for table={} partition={}",
                                     table, partitionValue, e);
                             return null;
                         }
-                    })
-                    .whenComplete((id, ex) -> inflight.remove(key));
+                    }, executor)
+                    .orTimeout(timeoutMinutes, TimeUnit.MINUTES)
+                    .whenComplete((id, ex) -> {
+                        if (id == null || ex != null) inflight.remove(key);
+                    });
         });
     }
 

--- a/src/main/java/com/datalathe/client/types/CreateChipRequest.java
+++ b/src/main/java/com/datalathe/client/types/CreateChipRequest.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -23,6 +25,10 @@ public class CreateChipRequest {
     @JsonProperty("storage_config")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private S3StorageConfig storageConfig;
+
+    @JsonProperty("tags")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Map<String, String> tags;
 
     public CreateChipRequest(SourceType sourceType, ChipSource source) {
         this.sourceType = sourceType;


### PR DESCRIPTION
## Summary
- **Inflight cache race**: Successful chip creations now stay cached until `searchChips` proves they're indexed, preventing duplicate creation from concurrent `resolve()` calls
- **Atomic create+tag**: Tags are sent in the `createChip` request body instead of a separate `addChipTags` call, eliminating orphan chips on partial failure
- **Dedicated thread pool**: Chip creation uses its own daemon thread pool instead of the common ForkJoinPool to avoid starving other async work
- **Timeout**: 10-minute timeout on chip creation futures so hung MySQL connections don't block the resolver permanently

## Test plan
- [ ] Run nCino example with concurrent report generation — verify no duplicate "Creating chip" log entries for the same table+partition
- [ ] Kill the app mid-chip-creation, restart, verify no orphan untagged chips accumulate
- [ ] Verify chips are still found via search on subsequent runs (inflight cache eviction works)