### PR TITLE
Release 1.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/AiConversation.java
+++ b/src/main/java/com/datalathe/client/AiConversation.java
@@ -1,0 +1,80 @@
+package com.datalathe.client;
+
+import com.datalathe.client.types.AiQueryResponse;
+import com.datalathe.client.types.ConversationTurn;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Client-side conversation helper that tracks conversation history locally.
+ * Use this for multi-turn AI queries without server-side session management.
+ *
+ * <pre>{@code
+ * AiConversation conversation = client.aiConversation(contextId, credentialId);
+ * AiQueryResponse r1 = conversation.ask("What is the total revenue by region?");
+ * AiQueryResponse r2 = conversation.ask("Break that down by product");
+ * }</pre>
+ */
+public class AiConversation {
+    private final DatalatheClient client;
+    private final String contextId;
+    private final String credentialId;
+    private final List<ConversationTurn> history = new ArrayList<>();
+
+    AiConversation(DatalatheClient client, String contextId, String credentialId) {
+        this.client = client;
+        this.contextId = contextId;
+        this.credentialId = credentialId;
+    }
+
+    /**
+     * Sends a question with the accumulated conversation history.
+     *
+     * @param question The natural language question
+     * @return The query response
+     * @throws IOException if the API call fails
+     */
+    public AiQueryResponse ask(String question) throws IOException {
+        return ask(question, null);
+    }
+
+    /**
+     * Sends a question with the accumulated conversation history and a model override.
+     *
+     * @param question The natural language question
+     * @param model    Optional model override
+     * @return The query response
+     * @throws IOException if the API call fails
+     */
+    public AiQueryResponse ask(String question, String model) throws IOException {
+        List<ConversationTurn> historySnapshot = history.isEmpty() ? null : new ArrayList<>(history);
+
+        AiQueryResponse response = client.aiQuery(contextId, credentialId, question, historySnapshot, model);
+
+        history.add(ConversationTurn.builder().role("user").content(question).build());
+        if (response.getAssistantTurn() != null) {
+            history.add(response.getAssistantTurn());
+        } else if (response.getExplanation() != null) {
+            history.add(ConversationTurn.builder().role("assistant").content(response.getExplanation()).build());
+        }
+
+        return response;
+    }
+
+    /**
+     * Returns an unmodifiable copy of the conversation history.
+     */
+    public List<ConversationTurn> getHistory() {
+        return Collections.unmodifiableList(new ArrayList<>(history));
+    }
+
+    /**
+     * Clears the conversation history.
+     */
+    public void clear() {
+        history.clear();
+    }
+}

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -784,6 +784,39 @@ public class DatalatheClient {
         return post("/lathe/ai/query", request, AiQueryResponse.class);
     }
 
+    /**
+     * Executes a natural language query using a pre-built request.
+     * Use this for session-based queries or when the credential is bound to the context.
+     *
+     * @param request The query request
+     * @return The query response (includes sessionId for follow-up queries)
+     * @throws IOException if the API call fails
+     */
+    public AiQueryResponse aiQuery(AiQueryRequest request) throws IOException {
+        return post("/lathe/ai/query", request, AiQueryResponse.class);
+    }
+
+    /**
+     * Creates a client-side conversation helper that tracks history locally.
+     *
+     * @param contextId    The AI context to query
+     * @param credentialId The AI credential to use
+     * @return An AiConversation that manages conversation turns
+     */
+    public AiConversation aiConversation(String contextId, String credentialId) {
+        return new AiConversation(this, contextId, credentialId);
+    }
+
+    /**
+     * Deletes a server-managed AI session.
+     *
+     * @param sessionId The session to delete
+     * @throws IOException if the API call fails
+     */
+    public void deleteAiSession(String sessionId) throws IOException {
+        httpDelete("/lathe/ai/sessions/" + URLEncoder.encode(sessionId, StandardCharsets.UTF_8));
+    }
+
     // --- HTTP helpers ---
 
     private <T> T get(String path, Class<T> responseType) throws IOException {

--- a/src/main/java/com/datalathe/client/types/AiContext.java
+++ b/src/main/java/com/datalathe/client/types/AiContext.java
@@ -1,5 +1,6 @@
 package com.datalathe.client.types;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +17,7 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AiContext {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/src/main/java/com/datalathe/client/types/AiCredential.java
+++ b/src/main/java/com/datalathe/client/types/AiCredential.java
@@ -1,5 +1,6 @@
 package com.datalathe.client.types;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AiCredential {
     @JsonProperty("credential_id")
     private String credentialId;
@@ -25,4 +27,7 @@ public class AiCredential {
 
     @JsonProperty("created_at")
     private long createdAt;
+
+    @JsonProperty("tenant_id")
+    private String tenantId;
 }

--- a/src/main/java/com/datalathe/client/types/AiQueryRequest.java
+++ b/src/main/java/com/datalathe/client/types/AiQueryRequest.java
@@ -18,6 +18,7 @@ public class AiQueryRequest {
     private String contextId;
 
     @JsonProperty("credential_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String credentialId;
 
     @JsonProperty("user_question")
@@ -26,6 +27,10 @@ public class AiQueryRequest {
     @JsonProperty("conversation_history")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<ConversationTurn> conversationHistory;
+
+    @JsonProperty("session_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String sessionId;
 
     @JsonProperty("model")
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/datalathe/client/types/AiQueryResponse.java
+++ b/src/main/java/com/datalathe/client/types/AiQueryResponse.java
@@ -33,6 +33,14 @@ public class AiQueryResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String generatedSql;
 
+    @JsonProperty("assistant_turn")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private ConversationTurn assistantTurn;
+
+    @JsonProperty("session_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String sessionId;
+
     @JsonProperty("usage")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private LlmUsage usage;

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -1,9 +1,13 @@
 package com.datalathe.client;
 
+import com.datalathe.client.types.AiQueryRequest;
+import com.datalathe.client.types.AiQueryResponse;
+import com.datalathe.client.types.ConversationTurn;
 import com.datalathe.client.types.GenerateReportResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -216,5 +220,92 @@ public class DatalatheClientTest {
                 // Verify timing is present
                 assertNotNull(reportResult.getTiming());
                 assertEquals(100, reportResult.getTiming().getTotalMs());
+        }
+
+        @Test
+        public void testAiQueryWithSessionId() throws Exception {
+                String responseJson = "{" +
+                        "\"request_id\":\"req1\"," +
+                        "\"explanation\":\"Total revenue is $1M\"," +
+                        "\"generated_sql\":\"SELECT SUM(revenue) FROM sales\"," +
+                        "\"assistant_turn\":{\"role\":\"assistant\",\"content\":\"Total revenue is $1M\"}," +
+                        "\"session_id\":\"sess-abc\"" +
+                        "}";
+
+                server.enqueue(new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(responseJson));
+
+                AiQueryResponse result = client.aiQuery(AiQueryRequest.builder()
+                        .contextId("ctx1")
+                        .userQuestion("What is total revenue?")
+                        .sessionId("sess-abc")
+                        .build());
+
+                assertEquals("sess-abc", result.getSessionId());
+                assertNotNull(result.getAssistantTurn());
+                assertEquals("assistant", result.getAssistantTurn().getRole());
+                assertEquals("Total revenue is $1M", result.getAssistantTurn().getContent());
+
+                RecordedRequest request = server.takeRequest();
+                String body = request.getBody().readUtf8();
+                assertTrue(body.contains("\"session_id\":\"sess-abc\""));
+                assertTrue(body.contains("\"context_id\":\"ctx1\""));
+                assertFalse(body.contains("\"credential_id\""));
+        }
+
+        @Test
+        public void testAiConversation() throws Exception {
+                String response1Json = "{" +
+                        "\"request_id\":\"req1\"," +
+                        "\"explanation\":\"Revenue is $1M\"," +
+                        "\"assistant_turn\":{\"role\":\"assistant\",\"content\":\"Revenue is $1M\"}" +
+                        "}";
+                String response2Json = "{" +
+                        "\"request_id\":\"req2\"," +
+                        "\"explanation\":\"By region: US $600K, EU $400K\"," +
+                        "\"assistant_turn\":{\"role\":\"assistant\",\"content\":\"By region: US $600K, EU $400K\"}" +
+                        "}";
+
+                server.enqueue(new MockResponse().setResponseCode(200).setBody(response1Json));
+                server.enqueue(new MockResponse().setResponseCode(200).setBody(response2Json));
+
+                AiConversation conversation = client.aiConversation("ctx1", "cred1");
+
+                AiQueryResponse r1 = conversation.ask("What is total revenue?");
+                assertEquals("Revenue is $1M", r1.getExplanation());
+
+                // First call should have no conversation history
+                RecordedRequest req1 = server.takeRequest();
+                String body1 = req1.getBody().readUtf8();
+                assertFalse(body1.contains("conversation_history"));
+
+                AiQueryResponse r2 = conversation.ask("Break that down by region");
+                assertEquals("By region: US $600K, EU $400K", r2.getExplanation());
+
+                // Second call should include history
+                RecordedRequest req2 = server.takeRequest();
+                String body2 = req2.getBody().readUtf8();
+                assertTrue(body2.contains("conversation_history"));
+                assertTrue(body2.contains("What is total revenue?"));
+                assertTrue(body2.contains("Revenue is $1M"));
+
+                // History should have 4 turns
+                List<ConversationTurn> history = conversation.getHistory();
+                assertEquals(4, history.size());
+                assertEquals("user", history.get(0).getRole());
+                assertEquals("What is total revenue?", history.get(0).getContent());
+                assertEquals("assistant", history.get(3).getRole());
+        }
+
+        @Test
+        public void testDeleteAiSession() throws Exception {
+                server.enqueue(new MockResponse().setResponseCode(200));
+
+                client.deleteAiSession("sess-abc");
+
+                RecordedRequest request = server.takeRequest();
+                assertEquals("DELETE", request.getMethod());
+                assertTrue(request.getPath().contains("/lathe/ai/sessions/sess-abc"));
         }
 }


### PR DESCRIPTION
## Summary
- Add AiConversation helper class for multi-turn AI queries
- Add AI query, credential, and context methods on DatalatheClient
- Add supporting types (AiContext, AiCredential, AiQueryRequest, AiQueryResponse)
- Bump to 1.2.6

## Test plan
- [ ] `mvn clean install` succeeds
- [ ] `mvn test` passes