### PR TITLE
Release 1.2.7: add default-headers support to DatalatheClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.2.6</version>
+    <version>1.2.7</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -2,7 +2,6 @@ package com.datalathe.client;
 
 import com.datalathe.client.types.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import okhttp3.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,17 +12,67 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-@RequiredArgsConstructor
 public class DatalatheClient {
     private static final Logger logger = LogManager.getLogger(DatalatheClient.class);
     private final String baseUrl;
-    private final OkHttpClient client = new OkHttpClient.Builder()
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(5, TimeUnit.MINUTES)
-            .writeTimeout(30, TimeUnit.SECONDS)
-            .build();
+    private final Map<String, String> defaultHeaders;
+    private final OkHttpClient client;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    /**
+     * Constructs a client without any default headers. Equivalent to
+     * {@code new DatalatheClient(baseUrl, Collections.emptyMap())}.
+     *
+     * <p>This constructor is backward compatible with the previous
+     * Lombok-generated single-arg constructor, so customer code calling
+     * {@code new DatalatheClient(url)} continues to work unchanged.</p>
+     *
+     * @param baseUrl the datalathe engine base URL (e.g. {@code http://host:3000})
+     */
+    public DatalatheClient(String baseUrl) {
+        this(baseUrl, Collections.emptyMap());
+    }
+
+    /**
+     * Constructs a client that adds the given headers to every outbound
+     * HTTP request. Headers are applied via an OkHttp {@link okhttp3.Interceptor}
+     * and take effect on ALL calls this client makes, including
+     * {@code get}, {@code post}, {@code put}, {@code delete}, and the
+     * hand-built {@link Request.Builder} in {@link #searchChips}.
+     *
+     * <p>Passing {@link Collections#emptyMap()} is equivalent to the
+     * single-arg constructor — no Interceptor is added when the map is
+     * empty.</p>
+     *
+     * <p>The map is defensively copied via {@link Map#copyOf}, so
+     * later mutations to the caller's map do not affect this client.</p>
+     *
+     * @param baseUrl        the datalathe engine base URL
+     * @param defaultHeaders headers to apply to every outbound request;
+     *                       pass an empty map for none
+     */
+    public DatalatheClient(String baseUrl, Map<String, String> defaultHeaders) {
+        this.baseUrl = baseUrl;
+        this.defaultHeaders = Map.copyOf(defaultHeaders);
+
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(5, TimeUnit.MINUTES)
+                .writeTimeout(30, TimeUnit.SECONDS);
+
+        if (!this.defaultHeaders.isEmpty()) {
+            builder.addInterceptor(chain -> {
+                Request.Builder rb = chain.request().newBuilder();
+                for (Map.Entry<String, String> e : this.defaultHeaders.entrySet()) {
+                    rb.header(e.getKey(), e.getValue());
+                }
+                return chain.proceed(rb.build());
+            });
+        }
+
+        this.client = builder.build();
+    }
 
     /**
      * Creates a chip from a source request

--- a/src/test/java/com/datalathe/client/DatalatheClientHeadersTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientHeadersTest.java
@@ -1,0 +1,101 @@
+package com.datalathe.client;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Verifies that {@link DatalatheClient}'s default-headers feature
+ * correctly injects caller-supplied headers on every outbound HTTP
+ * request, and that the single-arg constructor remains header-free
+ * for backward compatibility.
+ */
+class DatalatheClientHeadersTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() throws IOException {
+        server.shutdown();
+    }
+
+    /**
+     * Enqueues a canned empty SearchChipsResponse JSON body on the mock
+     * server. The client will deserialize this successfully; we only
+     * care about the recorded outbound request, not the response.
+     */
+    private void enqueueEmptySearchResponse() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"chips\":[],\"metadata\":[],\"tags\":[]}"));
+    }
+
+    private String baseUrl() {
+        // MockWebServer's url("/") returns something like "http://127.0.0.1:54321/"
+        // The client appends paths directly, so we strip the trailing slash.
+        String u = server.url("/").toString();
+        return u.endsWith("/") ? u.substring(0, u.length() - 1) : u;
+    }
+
+    @Test
+    void noDefaultHeaders_usesSingleArgConstructor_sendsNoDevKey() throws Exception {
+        enqueueEmptySearchResponse();
+        DatalatheClient client = new DatalatheClient(baseUrl());
+
+        client.searchChips("loan02", null, null, null);
+
+        RecordedRequest recorded = server.takeRequest();
+        assertNull(
+                recorded.getHeader("x-datalathe-dev-key"),
+                "single-arg constructor must not add any default headers");
+    }
+
+    @Test
+    void singleDefaultHeader_addsToOutboundRequest() throws Exception {
+        enqueueEmptySearchResponse();
+        DatalatheClient client = new DatalatheClient(
+                baseUrl(),
+                Map.of("x-datalathe-dev-key", "test-key"));
+
+        client.searchChips("loan02", null, null, null);
+
+        RecordedRequest recorded = server.takeRequest();
+        assertEquals(
+                "test-key",
+                recorded.getHeader("x-datalathe-dev-key"),
+                "the dev-key header should appear on outbound requests when the "
+                + "two-arg constructor is used");
+    }
+
+    @Test
+    void multipleDefaultHeaders_allAppearOnOutboundRequest() throws Exception {
+        enqueueEmptySearchResponse();
+        DatalatheClient client = new DatalatheClient(
+                baseUrl(),
+                Map.of(
+                        "x-datalathe-dev-key", "k",
+                        "x-custom-header", "c"));
+
+        client.searchChips("loan02", null, null, null);
+
+        RecordedRequest recorded = server.takeRequest();
+        assertEquals("k", recorded.getHeader("x-datalathe-dev-key"));
+        assertEquals("c", recorded.getHeader("x-custom-header"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new constructor `DatalatheClient(String baseUrl, Map<String, String> defaultHeaders)` that applies the supplied headers to every outbound HTTP request via an OkHttp `Interceptor`. The existing single-arg constructor `DatalatheClient(String baseUrl)` remains and is now equivalent to passing `Collections.emptyMap()` — customer code calling `new DatalatheClient(url)` continues to work unchanged.

Ships as `datalathe-client:1.2.7`. Needed by the Wave 3b smoke test harness in `datalathe-cdk` so it can inject the `x-datalathe-dev-key` header required by the backend dev-key middleware (shipped in `datalathe-backend:1.4.7` / Wave 0).

### Changes

- `pom.xml` — version bump `1.2.6` → `1.2.7`.
- `src/main/java/com/datalathe/client/DatalatheClient.java`:
  - Drop Lombok `@RequiredArgsConstructor`; remove the unused import.
  - Add `private final Map<String, String> defaultHeaders` field.
  - Move the `OkHttpClient client` field from a field initializer to constructor-assigned `final`.
  - Add a two-arg constructor that takes the headers map, wires an OkHttp `Interceptor` (only when the map is non-empty), and defensively copies the map via `Map.copyOf`.
  - Add a one-arg constructor that delegates to the two-arg with `Collections.emptyMap()`.
- `src/test/java/com/datalathe/client/DatalatheClientHeadersTest.java` (new) — 3 JUnit 5 tests using `okhttp-mockwebserver`:
  - single-arg constructor adds no default headers
  - single-header two-arg constructor adds exactly that header on every request
  - multi-header map all headers present on the outbound request

### Backward compatibility

Zero behavior change for callers of the existing `DatalatheClient(String baseUrl)` constructor. The Interceptor chain is only added when the defaultHeaders map is non-empty, so the single-arg path produces an OkHttp client identical to the previous version.

### Release

After merge:
1. \`mvn clean deploy\` from updated \`main\` → signs artifacts with GPG → publishes to Maven Central via the Central Publisher Portal.
2. \`git tag v1.2.7 && git push origin v1.2.7\`.
3. Wait ~15 min for Maven Central search index sync.

## Test plan

- [x] \`mvn clean test\` — 25 tests pass (22 existing + 3 new DatalatheClientHeadersTest)
- [x] \`mvn package\` — \`target/datalathe-client-1.2.7.jar\` produced cleanly
- [ ] \`mvn clean deploy\` after merge — artifact appears on Maven Central
- [ ] \`mvn dependency:get -Dartifact=com.datalathe:datalathe-client:1.2.7\` resolves from Central after the ~15-minute sync