### PR TITLE
Release 1.2.8: ChipNotFoundException for missing-chip recovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.2.7</version>
+    <version>1.2.8</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/ChipNotFoundException.java
+++ b/src/main/java/com/datalathe/client/ChipNotFoundException.java
@@ -1,0 +1,25 @@
+package com.datalathe.client;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a request references a chip whose data is no longer available
+ * (typically because the underlying S3 object has expired via lifecycle policy).
+ *
+ * <p>Recovery pattern: catch this exception, re-stage the chip from your own
+ * source-of-truth using the same chipId, then retry the original call.
+ */
+public class ChipNotFoundException extends IOException {
+    private static final long serialVersionUID = 1L;
+
+    private final String chipId;
+
+    public ChipNotFoundException(String chipId, String message) {
+        super(message);
+        this.chipId = chipId;
+    }
+
+    public String getChipId() {
+        return chipId;
+    }
+}

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -1,6 +1,7 @@
 package com.datalathe.client;
 
 import com.datalathe.client.types.*;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.*;
 import org.apache.logging.log4j.LogManager;
@@ -491,6 +492,19 @@ public class DatalatheClient {
     }
 
     /**
+     * Fetches a single chip (with sub-chips, metadata, and tags) by ID.
+     *
+     * @param chipId The chip ID to fetch.
+     * @return The chip's sub-chips, metadata, and tags.
+     * @throws ChipNotFoundException when the chip does not exist.
+     * @throws IOException for other API failures.
+     */
+    public SearchChipsResponse getChip(String chipId) throws IOException {
+        return get("/lathe/chips/" + URLEncoder.encode(chipId, StandardCharsets.UTF_8),
+                SearchChipsResponse.class);
+    }
+
+    /**
      * Gets a database connection by alias (password excluded).
      */
     public ConnectionInfo getConnection(String alias) throws IOException {
@@ -875,10 +889,11 @@ public class DatalatheClient {
                 .build();
 
         try (Response response = client.newCall(httpRequest).execute()) {
+            String responseBody = response.body() != null ? response.body().string() : "";
             if (!response.isSuccessful()) {
-                throw new IOException("GET " + path + " failed: " + response.code());
+                throwForFailure("GET", path, response.code(), responseBody);
             }
-            return objectMapper.readValue(response.body().string(), responseType);
+            return objectMapper.readValue(responseBody, responseType);
         }
     }
 
@@ -891,11 +906,11 @@ public class DatalatheClient {
         logger.debug("POST {}: {}", path, objectMapper.writeValueAsString(body));
 
         try (Response response = client.newCall(httpRequest).execute()) {
+            String responseBody = response.body() != null ? response.body().string() : "";
             if (!response.isSuccessful()) {
-                throw new IOException("POST " + path + " failed: " + response.code() + " "
-                        + response.body().string());
+                throwForFailure("POST", path, response.code(), responseBody);
             }
-            return objectMapper.readValue(response.body().string(), responseType);
+            return objectMapper.readValue(responseBody, responseType);
         }
     }
 
@@ -906,11 +921,11 @@ public class DatalatheClient {
                 .build();
 
         try (Response response = client.newCall(httpRequest).execute()) {
+            String responseBody = response.body() != null ? response.body().string() : "";
             if (!response.isSuccessful()) {
-                throw new IOException("PUT " + path + " failed: " + response.code() + " "
-                        + response.body().string());
+                throwForFailure("PUT", path, response.code(), responseBody);
             }
-            return objectMapper.readValue(response.body().string(), responseType);
+            return objectMapper.readValue(responseBody, responseType);
         }
     }
 
@@ -922,8 +937,34 @@ public class DatalatheClient {
 
         try (Response response = client.newCall(httpRequest).execute()) {
             if (!response.isSuccessful()) {
-                throw new IOException("DELETE " + path + " failed: " + response.code());
+                String responseBody = response.body() != null ? response.body().string() : "";
+                throwForFailure("DELETE", path, response.code(), responseBody);
             }
         }
+    }
+
+    /**
+     * Inspects a failed HTTP response and throws the most specific exception
+     * available. Falls through to a generic IOException for unrecognized errors.
+     */
+    private void throwForFailure(String method, String path, int statusCode, String body)
+            throws IOException {
+        if (statusCode == 404 && body != null && !body.isEmpty()) {
+            try {
+                JsonNode node = objectMapper.readTree(body);
+                JsonNode codeNode = node.get("error_code");
+                if (codeNode != null && "chip_not_found".equals(codeNode.asText())) {
+                    JsonNode chipIdNode = node.get("chip_id");
+                    JsonNode messageNode = node.get("error");
+                    String chipId = chipIdNode != null ? chipIdNode.asText() : null;
+                    String message = messageNode != null ? messageNode.asText()
+                            : "Chip not available";
+                    throw new ChipNotFoundException(chipId, message);
+                }
+            } catch (com.fasterxml.jackson.core.JsonProcessingException ignored) {
+                // Body wasn't JSON — fall through to the generic IOException.
+            }
+        }
+        throw new IOException(method + " " + path + " failed: " + statusCode + " " + body);
     }
 }

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -308,4 +308,59 @@ public class DatalatheClientTest {
                 assertEquals("DELETE", request.getMethod());
                 assertTrue(request.getPath().contains("/lathe/ai/sessions/sess-abc"));
         }
+
+        @Test
+        public void testChipNotFoundExceptionOnStructured404() throws Exception {
+                // Wire format contract with the engine: HTTP 404 + body
+                // {error_code: "chip_not_found", chip_id: ...} → ChipNotFoundException.
+                server.enqueue(new MockResponse()
+                                .setResponseCode(404)
+                                .setHeader("Content-Type", "application/json")
+                                .setBody("{\"error\":\"Chip 'abc123' is not available (may have expired)\","
+                                                + "\"error_code\":\"chip_not_found\",\"chip_id\":\"abc123\"}"));
+
+                try {
+                        client.generateReport(Arrays.asList("abc123"), Arrays.asList("SELECT 1"));
+                        fail("Expected ChipNotFoundException");
+                } catch (ChipNotFoundException e) {
+                        assertEquals("abc123", e.getChipId());
+                        // Back-compat: still catchable as IOException.
+                        assertTrue(e instanceof IOException);
+                }
+        }
+
+        @Test
+        public void testFallsBackToIOExceptionWhenErrorCodeMissing() throws Exception {
+                server.enqueue(new MockResponse()
+                                .setResponseCode(404)
+                                .setHeader("Content-Type", "application/json")
+                                .setBody("{\"error\":\"Some other 404\"}"));
+
+                try {
+                        client.generateReport(Arrays.asList("x"), Arrays.asList("SELECT 1"));
+                        fail("Expected IOException");
+                } catch (ChipNotFoundException e) {
+                        fail("Should not have thrown ChipNotFoundException");
+                } catch (IOException expected) {
+                        // OK
+                }
+        }
+
+        @Test
+        public void test500WithChipNotFoundCodeIsNotMisclassified() throws Exception {
+                // Defense in depth: only 404 should be inspected for the typed code.
+                server.enqueue(new MockResponse()
+                                .setResponseCode(500)
+                                .setHeader("Content-Type", "application/json")
+                                .setBody("{\"error_code\":\"chip_not_found\",\"chip_id\":\"abc\"}"));
+
+                try {
+                        client.generateReport(Arrays.asList("abc"), Arrays.asList("SELECT 1"));
+                        fail("Expected IOException");
+                } catch (ChipNotFoundException e) {
+                        fail("500 must not be classified as ChipNotFoundException");
+                } catch (IOException expected) {
+                        // OK
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- New `ChipNotFoundException` (extends `IOException`) carrying `chipId` — thrown when the engine returns HTTP 404 with `error_code: chip_not_found`.
- Centralized `throwForFailure(method, path, status, body)` helper used by all four HTTP helpers (`get`, `post`, `put`, `httpDelete`); falls back to generic `IOException` for unrecognized failures.
- Three JUnit cases lock the contract: structured 404 → typed exception with correct chipId; missing `error_code` falls back; 500 with the code is *not* misclassified.

Existing `catch (IOException)` blocks continue to work unchanged — typed handling is opt-in.

## Test plan
- [x] `mvn clean compile` clean
- [x] `mvn test` — 28 tests pass (was 25, +3 new)
- [ ] Maven Central deploy on tag