### PR TITLE
Add agent-mode endpoint, require defaultModel

### DIFF
--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -872,17 +872,11 @@ public class DatalatheClient {
     }
 
     /**
-     * Sends a natural-language question to the agent endpoint, which
-     * iteratively calls read-only tools against the configured chips before
-     * producing a final answer (with optional attachments and a
-     * chain-of-thought trace). Use this for analytical questions where
-     * the model needs to explore the data; use {@link #aiQuery(AiQueryRequest)}
-     * for direct text-to-SQL.
+     * Use this when the model needs to explore the chip data with read-only
+     * tools before answering; use {@link #aiQuery(AiQueryRequest)} for
+     * direct text-to-SQL.
      *
-     * @param request The agent request (context + question + optional caps)
-     * @return The agent response with answer, attachments, and trace
      * @throws ChipNotFoundException if a referenced chip is no longer available
-     * @throws IOException if the API call fails
      */
     public AgentResponse aiAgent(AgentRequest request) throws IOException {
         return post("/lathe/ai/agent", request, AgentResponse.class);

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -711,23 +711,35 @@ public class DatalatheClient {
     // --- AI Credential methods ---
 
     /**
-     * Creates a new AI credential.
+     * Creates a new AI credential. For bedrock (which requires a region) use
+     * {@link #createAiCredential(CreateAiCredentialRequest)}.
      *
      * @param name         Display name for the credential
-     * @param provider     AI provider (e.g. "anthropic", "openai")
+     * @param provider     AI provider — one of {@code "anthropic"}, {@code "openai"}, {@code "bedrock"}
      * @param apiKey       API key for the provider
-     * @param defaultModel Optional default model to use
+     * @param defaultModel Required. Model to use when a request omits an override.
      * @return The created credential
      * @throws IOException if the API call fails
      */
     public AiCredential createAiCredential(String name, String provider, String apiKey,
             String defaultModel) throws IOException {
-        CreateAiCredentialRequest request = CreateAiCredentialRequest.builder()
+        return createAiCredential(CreateAiCredentialRequest.builder()
                 .name(name)
                 .provider(provider)
                 .apiKey(apiKey)
                 .defaultModel(defaultModel)
-                .build();
+                .build());
+    }
+
+    /**
+     * Creates a new AI credential from a pre-built request. Use this overload
+     * when registering a {@code bedrock} credential that needs a region.
+     *
+     * @param request The credential creation request
+     * @return The created credential
+     * @throws IOException if the API call fails
+     */
+    public AiCredential createAiCredential(CreateAiCredentialRequest request) throws IOException {
         return post("/lathe/ai/credentials", request, AiCredential.class);
     }
 
@@ -857,6 +869,23 @@ public class DatalatheClient {
      */
     public AiQueryResponse aiQuery(AiQueryRequest request) throws IOException {
         return post("/lathe/ai/query", request, AiQueryResponse.class);
+    }
+
+    /**
+     * Sends a natural-language question to the agent endpoint, which
+     * iteratively calls read-only tools against the configured chips before
+     * producing a final answer (with optional attachments and a
+     * chain-of-thought trace). Use this for analytical questions where
+     * the model needs to explore the data; use {@link #aiQuery(AiQueryRequest)}
+     * for direct text-to-SQL.
+     *
+     * @param request The agent request (context + question + optional caps)
+     * @return The agent response with answer, attachments, and trace
+     * @throws ChipNotFoundException if a referenced chip is no longer available
+     * @throws IOException if the API call fails
+     */
+    public AgentResponse aiAgent(AgentRequest request) throws IOException {
+        return post("/lathe/ai/agent", request, AgentResponse.class);
     }
 
     /**

--- a/src/main/java/com/datalathe/client/types/AgentOptions.java
+++ b/src/main/java/com/datalathe/client/types/AgentOptions.java
@@ -1,0 +1,43 @@
+package com.datalathe.client.types;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Per-request budget cap overrides for the agent tool loop.
+ * Null fields fall back to server defaults.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AgentOptions {
+    /** Force-final after N tool-using iterations (soft cap). */
+    @JsonProperty("max_iterations")
+    private Integer maxIterations;
+
+    /** Force-final after N total tool calls (soft cap). */
+    @JsonProperty("max_tool_calls")
+    private Integer maxToolCalls;
+
+    /** Abort after N seconds of wall-clock time (hard cap). */
+    @JsonProperty("max_wall_clock_secs")
+    private Long maxWallClockSecs;
+
+    /** Force-final once N attachments have been emitted (soft cap). */
+    @JsonProperty("max_attachments")
+    private Integer maxAttachments;
+
+    /** Truncate run_sql results to this many rows. */
+    @JsonProperty("run_sql_row_cap")
+    private Integer runSqlRowCap;
+
+    /** Abort once cumulative input token usage exceeds this (hard cap). */
+    @JsonProperty("max_total_input_tokens")
+    private Integer maxTotalInputTokens;
+}

--- a/src/main/java/com/datalathe/client/types/AgentRequest.java
+++ b/src/main/java/com/datalathe/client/types/AgentRequest.java
@@ -1,0 +1,51 @@
+package com.datalathe.client.types;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request body for {@code POST /lathe/ai/agent}. The agent endpoint
+ * iteratively calls read-only tools against the chips bound to
+ * {@code contextId} before producing a final answer.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgentRequest {
+    @JsonProperty("context_id")
+    private String contextId;
+
+    @JsonProperty("user_question")
+    private String userQuestion;
+
+    @JsonProperty("credential_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String credentialId;
+
+    @JsonProperty("session_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String sessionId;
+
+    @JsonProperty("conversation_history")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<ConversationTurn> conversationHistory;
+
+    @JsonProperty("model")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String model;
+
+    @JsonProperty("tenant_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String tenantId;
+
+    @JsonProperty("agent_options")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private AgentOptions agentOptions;
+}

--- a/src/main/java/com/datalathe/client/types/AgentRequest.java
+++ b/src/main/java/com/datalathe/client/types/AgentRequest.java
@@ -10,14 +10,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Request body for {@code POST /lathe/ai/agent}. The agent endpoint
- * iteratively calls read-only tools against the chips bound to
- * {@code contextId} before producing a final answer.
+ * Request body for {@code POST /lathe/ai/agent}. Use this when the model
+ * needs to explore the chip data with read-only tools before answering;
+ * use {@link AiQueryRequest} for direct text-to-SQL.
  */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AgentRequest {
     @JsonProperty("context_id")
     private String contextId;
@@ -26,26 +27,20 @@ public class AgentRequest {
     private String userQuestion;
 
     @JsonProperty("credential_id")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String credentialId;
 
     @JsonProperty("session_id")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String sessionId;
 
     @JsonProperty("conversation_history")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<ConversationTurn> conversationHistory;
 
     @JsonProperty("model")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String model;
 
     @JsonProperty("tenant_id")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String tenantId;
 
     @JsonProperty("agent_options")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private AgentOptions agentOptions;
 }

--- a/src/main/java/com/datalathe/client/types/AgentResponse.java
+++ b/src/main/java/com/datalathe/client/types/AgentResponse.java
@@ -1,0 +1,153 @@
+package com.datalathe.client.types;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response from {@code POST /lathe/ai/agent}. {@link #toolCalls} and
+ * {@link #narration} carry the chain-of-thought trace; pair them by
+ * iteration to render the full reasoning. {@link #attachments} carry
+ * any data tables/visualizations the agent decided to surface.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AgentResponse {
+    @JsonProperty("request_id")
+    private String requestId;
+
+    @JsonProperty("answer")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String answer;
+
+    /** Always present; empty list if the agent surfaced no tabular data. */
+    @JsonProperty("attachments")
+    private List<Attachment> attachments;
+
+    /** Always present; empty list on errors or if no tools were called. */
+    @JsonProperty("tool_calls")
+    private List<ToolCallTrace> toolCalls;
+
+    /** Always present; empty list on errors. */
+    @JsonProperty("narration")
+    private List<NarrationEntry> narration;
+
+    @JsonProperty("session_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String sessionId;
+
+    @JsonProperty("stop_reason")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private StopReason stopReason;
+
+    @JsonProperty("usage")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private AgentUsage usage;
+
+    @JsonProperty("error")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String error;
+
+    /** Stable machine-readable error code (e.g. {@code "chip_not_found"}). */
+    @JsonProperty("error_code")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String errorCode;
+
+    /** Set when {@code errorCode == "chip_not_found"}. */
+    @JsonProperty("chip_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String chipId;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Attachment {
+        @JsonProperty("caption")
+        private String caption;
+
+        @JsonProperty("sql")
+        private String sql;
+
+        @JsonProperty("data")
+        private AiQueryResponse.QueryResultData data;
+
+        @JsonProperty("visualization")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private AiQueryResponse.VisualizationConfig visualization;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ToolCallTrace {
+        @JsonProperty("iteration")
+        private int iteration;
+
+        @JsonProperty("tool")
+        private String tool;
+
+        /** Raw arguments the model passed to the tool — shape varies per tool. */
+        @JsonProperty("args")
+        private JsonNode args;
+
+        @JsonProperty("result_summary")
+        private String resultSummary;
+
+        @JsonProperty("duration_ms")
+        private long durationMs;
+
+        @JsonProperty("is_error")
+        private boolean isError;
+    }
+
+    /**
+     * Natural-language reasoning emitted between tool calls. Currently the
+     * only variant is {@code kind="assistant_text"}; future variants would
+     * be added here.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class NarrationEntry {
+        @JsonProperty("kind")
+        private String kind;
+
+        @JsonProperty("iteration")
+        private int iteration;
+
+        @JsonProperty("text")
+        private String text;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class AgentUsage {
+        @JsonProperty("input_tokens")
+        private int inputTokens;
+
+        @JsonProperty("output_tokens")
+        private int outputTokens;
+
+        @JsonProperty("model")
+        private String model;
+
+        @JsonProperty("iterations")
+        private int iterations;
+
+        @JsonProperty("tool_calls")
+        private int toolCalls;
+    }
+}

--- a/src/main/java/com/datalathe/client/types/AiCredential.java
+++ b/src/main/java/com/datalathe/client/types/AiCredential.java
@@ -30,4 +30,7 @@ public class AiCredential {
 
     @JsonProperty("tenant_id")
     private String tenantId;
+
+    @JsonProperty("region")
+    private String region;
 }

--- a/src/main/java/com/datalathe/client/types/AiQueryResponse.java
+++ b/src/main/java/com/datalathe/client/types/AiQueryResponse.java
@@ -49,6 +49,16 @@ public class AiQueryResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String error;
 
+    /** Stable machine-readable error code (e.g. {@code "chip_not_found"}). */
+    @JsonProperty("error_code")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String errorCode;
+
+    /** Set when {@code errorCode == "chip_not_found"}. */
+    @JsonProperty("chip_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String chipId;
+
     @Data
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/com/datalathe/client/types/CreateAiCredentialRequest.java
+++ b/src/main/java/com/datalathe/client/types/CreateAiCredentialRequest.java
@@ -21,7 +21,15 @@ public class CreateAiCredentialRequest {
     @JsonProperty("api_key")
     private String apiKey;
 
+    /**
+     * Required. The server-side fallback was removed because hardcoded
+     * per-provider defaults silently rotted as new model versions shipped.
+     */
     @JsonProperty("default_model")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String defaultModel;
+
+    /** Required when {@code provider} is {@code "bedrock"}. */
+    @JsonProperty("region")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String region;
 }

--- a/src/main/java/com/datalathe/client/types/CreateAiCredentialRequest.java
+++ b/src/main/java/com/datalathe/client/types/CreateAiCredentialRequest.java
@@ -21,10 +21,7 @@ public class CreateAiCredentialRequest {
     @JsonProperty("api_key")
     private String apiKey;
 
-    /**
-     * Required. The server-side fallback was removed because hardcoded
-     * per-provider defaults silently rotted as new model versions shipped.
-     */
+    /** Required by server. */
     @JsonProperty("default_model")
     private String defaultModel;
 

--- a/src/main/java/com/datalathe/client/types/StopReason.java
+++ b/src/main/java/com/datalathe/client/types/StopReason.java
@@ -1,40 +1,16 @@
 package com.datalathe.client.types;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Reason the agent loop stopped. The model emitted a final answer for
- * {@link #END_TURN}; all other variants indicate a budget cap forced the
- * loop to wrap up. {@link #AGENT_BUDGET_EXHAUSTED} additionally implies a
- * hard cap (wall-clock or token budget) was hit, in which case the response
- * may be missing an {@code answer}.
+ * Reason the agent loop stopped. {@link #END_TURN} means the model emitted
+ * a final answer; the others mean a budget cap forced the loop to wrap up.
+ * On {@link #AGENT_BUDGET_EXHAUSTED} the response may be missing an answer.
  */
 public enum StopReason {
-    END_TURN("end_turn"),
-    MAX_ITERATIONS("max_iterations"),
-    MAX_TOOL_CALLS("max_tool_calls"),
-    MAX_ATTACHMENTS("max_attachments"),
-    AGENT_BUDGET_EXHAUSTED("agent_budget_exhausted");
-
-    private final String wireValue;
-
-    StopReason(String wireValue) {
-        this.wireValue = wireValue;
-    }
-
-    @JsonValue
-    public String wireValue() {
-        return wireValue;
-    }
-
-    @JsonCreator
-    public static StopReason fromWire(String value) {
-        for (StopReason r : values()) {
-            if (r.wireValue.equals(value)) {
-                return r;
-            }
-        }
-        throw new IllegalArgumentException("Unknown StopReason: " + value);
-    }
+    @JsonProperty("end_turn") END_TURN,
+    @JsonProperty("max_iterations") MAX_ITERATIONS,
+    @JsonProperty("max_tool_calls") MAX_TOOL_CALLS,
+    @JsonProperty("max_attachments") MAX_ATTACHMENTS,
+    @JsonProperty("agent_budget_exhausted") AGENT_BUDGET_EXHAUSTED
 }

--- a/src/main/java/com/datalathe/client/types/StopReason.java
+++ b/src/main/java/com/datalathe/client/types/StopReason.java
@@ -1,0 +1,40 @@
+package com.datalathe.client.types;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Reason the agent loop stopped. The model emitted a final answer for
+ * {@link #END_TURN}; all other variants indicate a budget cap forced the
+ * loop to wrap up. {@link #AGENT_BUDGET_EXHAUSTED} additionally implies a
+ * hard cap (wall-clock or token budget) was hit, in which case the response
+ * may be missing an {@code answer}.
+ */
+public enum StopReason {
+    END_TURN("end_turn"),
+    MAX_ITERATIONS("max_iterations"),
+    MAX_TOOL_CALLS("max_tool_calls"),
+    MAX_ATTACHMENTS("max_attachments"),
+    AGENT_BUDGET_EXHAUSTED("agent_budget_exhausted");
+
+    private final String wireValue;
+
+    StopReason(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    @JsonValue
+    public String wireValue() {
+        return wireValue;
+    }
+
+    @JsonCreator
+    public static StopReason fromWire(String value) {
+        for (StopReason r : values()) {
+            if (r.wireValue.equals(value)) {
+                return r;
+            }
+        }
+        throw new IllegalArgumentException("Unknown StopReason: " + value);
+    }
+}

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -1,9 +1,15 @@
 package com.datalathe.client;
 
+import com.datalathe.client.types.AgentOptions;
+import com.datalathe.client.types.AgentRequest;
+import com.datalathe.client.types.AgentResponse;
+import com.datalathe.client.types.AiCredential;
 import com.datalathe.client.types.AiQueryRequest;
 import com.datalathe.client.types.AiQueryResponse;
 import com.datalathe.client.types.ConversationTurn;
+import com.datalathe.client.types.CreateAiCredentialRequest;
 import com.datalathe.client.types.GenerateReportResponse;
+import com.datalathe.client.types.StopReason;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -343,6 +349,150 @@ public class DatalatheClientTest {
                         fail("Should not have thrown ChipNotFoundException");
                 } catch (IOException expected) {
                         // OK
+                }
+        }
+
+        @Test
+        public void testCreateAiCredentialWithBedrockRegion() throws Exception {
+                server.enqueue(new MockResponse()
+                                .setResponseCode(200)
+                                .setBody("{\"credential_id\":\"cred1\",\"name\":\"bedrock-prod\","
+                                                + "\"provider\":\"bedrock\","
+                                                + "\"default_model\":\"anthropic.claude-sonnet-4-5-20250929-v1:0\","
+                                                + "\"created_at\":1,\"region\":\"us-west-2\"}"));
+
+                AiCredential cred = client.createAiCredential(CreateAiCredentialRequest.builder()
+                                .name("bedrock-prod")
+                                .provider("bedrock")
+                                .apiKey("secret")
+                                .defaultModel("anthropic.claude-sonnet-4-5-20250929-v1:0")
+                                .region("us-west-2")
+                                .build());
+
+                assertEquals("us-west-2", cred.getRegion());
+
+                String body = server.takeRequest().getBody().readUtf8();
+                assertTrue(body.contains("\"region\":\"us-west-2\""));
+                assertTrue(body.contains("\"default_model\":\"anthropic.claude-sonnet-4-5-20250929-v1:0\""));
+                assertTrue(body.contains("\"api_key\":\"secret\""));
+        }
+
+        @Test
+        public void testCreateAiCredentialOmitsRegionForNonBedrock() throws Exception {
+                server.enqueue(new MockResponse()
+                                .setResponseCode(200)
+                                .setBody("{\"credential_id\":\"cred1\",\"name\":\"anthropic\","
+                                                + "\"provider\":\"anthropic\","
+                                                + "\"default_model\":\"claude-sonnet-4-5-20250929\","
+                                                + "\"created_at\":1}"));
+
+                client.createAiCredential("anthropic", "anthropic", "secret",
+                                "claude-sonnet-4-5-20250929");
+
+                String body = server.takeRequest().getBody().readUtf8();
+                // region must be omitted entirely (NON_NULL on the request type)
+                assertFalse(body.contains("\"region\""));
+        }
+
+        @Test
+        public void testAiAgentParsesFullResponse() throws Exception {
+                String responseJson = "{"
+                                + "\"request_id\":\"req1\","
+                                + "\"answer\":\"LATAM had the highest growth at 23%.\","
+                                + "\"attachments\":[{"
+                                + "  \"caption\":\"Growth by region\","
+                                + "  \"sql\":\"SELECT region, growth FROM sales\","
+                                + "  \"data\":{\"columns\":[{\"name\":\"region\",\"data_type\":\"Utf8\"},"
+                                + "                        {\"name\":\"growth\",\"data_type\":\"Float64\"}],"
+                                + "           \"rows\":[[\"LATAM\",\"0.23\"]]},"
+                                + "  \"visualization\":{\"type\":\"bar\",\"x_axis\":\"region\",\"y_axis\":\"growth\"}"
+                                + "}],"
+                                + "\"tool_calls\":[{"
+                                + "  \"iteration\":1,\"tool\":\"list_tables\",\"args\":{},"
+                                + "  \"result_summary\":\"Found 3 tables\",\"duration_ms\":12,\"is_error\":false"
+                                + "}],"
+                                + "\"narration\":[{\"kind\":\"assistant_text\",\"iteration\":1,"
+                                + "                \"text\":\"Let me look at the tables.\"}],"
+                                + "\"session_id\":\"sess-abc\","
+                                + "\"stop_reason\":\"end_turn\","
+                                + "\"usage\":{\"input_tokens\":1500,\"output_tokens\":200,"
+                                + "          \"model\":\"claude-sonnet-4-5-20250929\","
+                                + "          \"iterations\":2,\"tool_calls\":1}"
+                                + "}";
+
+                server.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
+
+                AgentResponse result = client.aiAgent(AgentRequest.builder()
+                                .contextId("ctx1")
+                                .credentialId("cred1")
+                                .userQuestion("Which region had the highest growth?")
+                                .sessionId("sess-abc")
+                                .agentOptions(AgentOptions.builder()
+                                                .maxIterations(5)
+                                                .runSqlRowCap(1000)
+                                                .build())
+                                .build());
+
+                assertEquals("req1", result.getRequestId());
+                assertEquals("LATAM had the highest growth at 23%.", result.getAnswer());
+                assertEquals(StopReason.END_TURN, result.getStopReason());
+                assertEquals(1, result.getAttachments().size());
+                assertEquals("Growth by region", result.getAttachments().get(0).getCaption());
+                assertEquals("region",
+                                result.getAttachments().get(0).getVisualization().getXAxis());
+                assertEquals(1, result.getToolCalls().size());
+                assertEquals(1, result.getToolCalls().get(0).getIteration());
+                assertEquals("Found 3 tables", result.getToolCalls().get(0).getResultSummary());
+                assertFalse(result.getToolCalls().get(0).isError());
+                assertEquals("assistant_text", result.getNarration().get(0).getKind());
+                assertEquals(1, result.getUsage().getToolCalls());
+                assertEquals(1500, result.getUsage().getInputTokens());
+
+                RecordedRequest request = server.takeRequest();
+                assertTrue(request.getPath().endsWith("/lathe/ai/agent"));
+                String body = request.getBody().readUtf8();
+                assertTrue(body.contains("\"context_id\":\"ctx1\""));
+                assertTrue(body.contains("\"user_question\":\"Which region had the highest growth?\""));
+                assertTrue(body.contains("\"credential_id\":\"cred1\""));
+                assertTrue(body.contains("\"session_id\":\"sess-abc\""));
+                assertTrue(body.contains("\"max_iterations\":5"));
+                assertTrue(body.contains("\"run_sql_row_cap\":1000"));
+                // Unset cap fields must be omitted (NON_NULL on AgentOptions)
+                assertFalse(body.contains("max_tool_calls"));
+        }
+
+        @Test
+        public void testAiAgentOmitsAgentOptionsWhenNotProvided() throws Exception {
+                server.enqueue(new MockResponse().setResponseCode(200).setBody(
+                                "{\"request_id\":\"r\",\"answer\":\"ok\","
+                                                + "\"attachments\":[],\"tool_calls\":[],\"narration\":[]}"));
+
+                client.aiAgent(AgentRequest.builder()
+                                .contextId("ctx1")
+                                .userQuestion("Hi")
+                                .build());
+
+                String body = server.takeRequest().getBody().readUtf8();
+                assertFalse(body.contains("agent_options"));
+                assertFalse(body.contains("credential_id"));
+        }
+
+        @Test
+        public void testAiAgentSurfacesChipNotFoundOn404() throws Exception {
+                server.enqueue(new MockResponse()
+                                .setResponseCode(404)
+                                .setHeader("Content-Type", "application/json")
+                                .setBody("{\"error\":\"Chip 'lost' is not available (may have expired)\","
+                                                + "\"error_code\":\"chip_not_found\",\"chip_id\":\"lost\"}"));
+
+                try {
+                        client.aiAgent(AgentRequest.builder()
+                                        .contextId("ctx1")
+                                        .userQuestion("Q")
+                                        .build());
+                        fail("Expected ChipNotFoundException");
+                } catch (ChipNotFoundException e) {
+                        assertEquals("lost", e.getChipId());
                 }
         }
 


### PR DESCRIPTION
## Summary

- `client.aiAgent(AgentRequest)` calls the new `POST /lathe/ai/agent` endpoint with the full request surface (history, model override, per-request budget caps via `AgentOptions`). Response carries `answer`, `attachments`, `toolCalls` (with `iteration` + `isError`), `narration`, `stopReason`, `usage`, and the same `chip_not_found` recovery path as `aiQuery()`.
- `CreateAiCredentialRequest.defaultModel` is now **required**. Mirrors the backend change — hardcoded per-provider defaults silently rotted (anthropic was pinned to a May model and never advanced), so operators now have to pick one explicitly. Adds optional `region` for `bedrock`, plus a new `createAiCredential(CreateAiCredentialRequest)` overload so bedrock callers can pass it.
- `AiQueryResponse` now exposes `errorCode` and `chipId` so SDK consumers can branch on stable codes without parsing `error`.

Pairs with the backend PR (`feature/ai-agent-mode` on `datalathe-backend`) and the JS SDK PR (`feature/ai-agent-mode` on `datalathe-client-javascript`).

## Test plan
- [x] `mvn test` — 33 tests pass (5 new: bedrock region wire format, omit-region default, full agent request/response round-trip with stop reason + tool trace + narration, agent-mode `agent_options` omission, agent `ChipNotFoundException` on 404)
- [ ] Once the backend PR lands, smoke-test `aiAgent()` against a running engine