### PR TITLE
Release 1.4.0: streaming MySQL ingest support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/types/ChipSource.java
+++ b/src/main/java/com/datalathe/client/types/ChipSource.java
@@ -53,6 +53,22 @@ public class ChipSource {
     @JsonProperty("storage_config")
     private S3StorageConfig storageConfig;
 
+    /**
+     * When {@code true}, the engine uses a streaming cursor for ingest (MySQL only).
+     * Omitted from the request when {@code false} or unset, preserving buffered behavior.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("streaming")
+    private Boolean streaming;
+
+    /**
+     * Optional numeric primary key column for keyset-parallel chunked ingest.
+     * Only meaningful when {@link #streaming} is {@code true}.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("partition_column")
+    private String partitionColumn;
+
     public ChipSource(String databaseName, String tableName, String query) {
         this.databaseName = databaseName;
         this.tableName = tableName;

--- a/src/main/java/com/datalathe/client/types/CreateChipResponse.java
+++ b/src/main/java/com/datalathe/client/types/CreateChipResponse.java
@@ -1,5 +1,6 @@
 package com.datalathe.client.types;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,4 +13,19 @@ public class CreateChipResponse {
 
     @JsonProperty("error")
     private String error;
+
+    /**
+     * Total rows ingested. Present on successful streaming ingest responses; absent otherwise.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("total_rows")
+    private Long totalRows;
+
+    /**
+     * Wall-clock ingest duration in milliseconds. Present on successful streaming ingest
+     * responses; absent otherwise.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("elapsed_ms")
+    private Long elapsedMs;
 }

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -6,9 +6,12 @@ import com.datalathe.client.types.AgentResponse;
 import com.datalathe.client.types.AiCredential;
 import com.datalathe.client.types.AiQueryRequest;
 import com.datalathe.client.types.AiQueryResponse;
+import com.datalathe.client.types.ChipSource;
 import com.datalathe.client.types.ConversationTurn;
 import com.datalathe.client.types.CreateAiCredentialRequest;
+import com.datalathe.client.types.CreateChipResponse;
 import com.datalathe.client.types.GenerateReportResponse;
+import com.datalathe.client.types.SourceType;
 import com.datalathe.client.types.StopReason;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
@@ -512,5 +515,42 @@ public class DatalatheClientTest {
                 } catch (IOException expected) {
                         // OK
                 }
+        }
+
+        @Test
+        public void testStreamingFieldsSerializedInRequest() throws Exception {
+                server.enqueue(new MockResponse()
+                                .setResponseCode(200)
+                                .setBody("{\"chip_id\":\"chip-stream-1\",\"error\":null,"
+                                                + "\"total_rows\":200000000,\"elapsed_ms\":1843121}"));
+
+                ChipSource source = ChipSource.builder()
+                                .sourceType(SourceType.MYSQL)
+                                .databaseName("prod_db")
+                                .tableName("events")
+                                .query("SELECT * FROM events")
+                                .streaming(true)
+                                .partitionColumn("id")
+                                .build();
+
+                client.createChip(source);
+
+                String body = server.takeRequest().getBody().readUtf8();
+                assertTrue("streaming field must be serialized", body.contains("\"streaming\":true"));
+                assertTrue("partition_column field must be serialized",
+                                body.contains("\"partition_column\":\"id\""));
+        }
+
+        @Test
+        public void testStreamingResponseFieldsDeserialized() throws Exception {
+                ObjectMapper mapper = new ObjectMapper();
+                String json = "{\"chip_id\":\"chip-stream-1\",\"error\":null,"
+                                + "\"total_rows\":200000000,\"elapsed_ms\":1843121}";
+
+                CreateChipResponse response = mapper.readValue(json, CreateChipResponse.class);
+
+                assertEquals("chip-stream-1", response.getChipId());
+                assertEquals(200000000L, (long) response.getTotalRows());
+                assertEquals(1843121L, (long) response.getElapsedMs());
         }
 }


### PR DESCRIPTION
## Summary
- Adds optional `streaming` and `partitionColumn` fields to `ChipSource` for opt-in v1.7 backend streaming MySQL ingest
- Adds optional `totalRows` / `elapsedMs` to `CreateChipResponse`
- Bumps pom.xml to 1.4.0

## Test plan
- [x] `mvn clean test` — 35 pass (was 33; 2 new tests verify JSON serialization + response deserialization)
- [ ] Tag push triggers Maven Central publish via CI