### PR TITLE
Surface empty/non-JSON response bodies as a clear IOException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -578,10 +578,11 @@ public class DatalatheClient {
         logger.debug("Searching chips: {}", httpRequest.url());
 
         try (Response response = client.newCall(httpRequest).execute()) {
+            String responseBody = response.body() != null ? response.body().string() : "";
             if (!response.isSuccessful()) {
-                throw new IOException("Failed to search chips: " + response.code() + " " + response.body().string());
+                throw new IOException("Failed to search chips: " + response.code() + " " + responseBody);
             }
-            return objectMapper.readValue(response.body().string(), SearchChipsResponse.class);
+            return parseBody("GET", url.toString(), response.code(), responseBody, SearchChipsResponse.class);
         }
     }
 
@@ -916,7 +917,7 @@ public class DatalatheClient {
             if (!response.isSuccessful()) {
                 throwForFailure("GET", path, response.code(), responseBody);
             }
-            return objectMapper.readValue(responseBody, responseType);
+            return parseBody("GET", path, response.code(), responseBody, responseType);
         }
     }
 
@@ -933,7 +934,7 @@ public class DatalatheClient {
             if (!response.isSuccessful()) {
                 throwForFailure("POST", path, response.code(), responseBody);
             }
-            return objectMapper.readValue(responseBody, responseType);
+            return parseBody("POST", path, response.code(), responseBody, responseType);
         }
     }
 
@@ -948,7 +949,7 @@ public class DatalatheClient {
             if (!response.isSuccessful()) {
                 throwForFailure("PUT", path, response.code(), responseBody);
             }
-            return objectMapper.readValue(responseBody, responseType);
+            return parseBody("PUT", path, response.code(), responseBody, responseType);
         }
     }
 
@@ -963,6 +964,20 @@ public class DatalatheClient {
                 String responseBody = response.body() != null ? response.body().string() : "";
                 throwForFailure("DELETE", path, response.code(), responseBody);
             }
+        }
+    }
+
+    private <T> T parseBody(String method, String path, int status, String body, Class<T> responseType)
+            throws IOException {
+        if (body == null || body.trim().isEmpty()) {
+            throw new IOException(method + " " + path + " returned " + status
+                    + " with an empty response body");
+        }
+        try {
+            return objectMapper.readValue(body, responseType);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new IOException(method + " " + path + " returned " + status
+                    + " with a non-JSON response body: " + body, e);
         }
     }
 

--- a/src/test/java/com/datalathe/client/EmptyResponseBodyTest.java
+++ b/src/test/java/com/datalathe/client/EmptyResponseBodyTest.java
@@ -1,0 +1,36 @@
+package com.datalathe.client;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+
+class EmptyResponseBodyTest {
+
+    @Test
+    void emptyBodyOn200SurfacesAsIOException() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200).setBody(""));
+            server.start();
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+            IOException ex = assertThrows(IOException.class, () -> client.listChips());
+            assertTrue(ex.getMessage().contains("200"), () -> "message was: " + ex.getMessage());
+        }
+    }
+
+    @Test
+    void nonJsonBodyOn200SurfacesAsIOException() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200).setBody("<html>oops</html>"));
+            server.start();
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+            IOException ex = assertThrows(IOException.class, () -> client.listChips());
+            assertTrue(ex.getMessage().contains("oops"), () -> "message was: " + ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The HTTP layer parses successful (2xx) response bodies as JSON without guarding empty or non-JSON bodies. When the server returns a 2xx with an empty body (which has happened in practice — a backend fault), the raw JSON-decode exception bubbles to the caller instead of the SDK's typed API error, producing a cryptic message like `Expecting value: line 1 column 1 (char 0)`.

## Change

A small wrapper around every 2xx-body JSON parse: an empty or unparseable body now surfaces as the SDK's normal typed API error carrying the HTTP status and the raw body text — the same shape callers already get for 5xx. No behavior change for valid responses.

Tests cover an empty 2xx body and a non-JSON 2xx body.

Part of a cross-repo hardening effort (see datalathe `docs/superpowers/specs/2026-05-11-chip-manager-poison-row-hardening-design.md`).