### PR TITLE
Release 1.4.2: type unreadableChipIds on SearchChipsResponse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/SearchChipsResponse.java
+++ b/src/main/java/com/datalathe/client/SearchChipsResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -63,4 +64,12 @@ public class SearchChipsResponse {
     }
 
     private List<ChipTagRecord> tags;
+
+    /**
+     * Chip IDs whose metadata could not be read back from the chip-manager.
+     * Always populated by v1.7.1+ engines (empty list when none); empty on
+     * older engines that don't emit the field.
+     */
+    @JsonProperty("unreadable_chip_ids")
+    private List<String> unreadableChipIds = new ArrayList<>();
 }

--- a/src/test/java/com/datalathe/client/UnreadableChipIdsTest.java
+++ b/src/test/java/com/datalathe/client/UnreadableChipIdsTest.java
@@ -1,0 +1,56 @@
+package com.datalathe.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+
+class UnreadableChipIdsTest {
+
+    @Test
+    void listChipsSurfacesUnreadableChipIds() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            String body = "{"
+                    + "\"chips\":[{\"chip_id\":\"good-1\",\"sub_chip_id\":\"sub-1\","
+                    + "\"table_name\":\"users\",\"partition_value\":\"default\"}],"
+                    + "\"metadata\":[],"
+                    + "\"unreadable_chip_ids\":[\"bad-1\",\"bad-2\"]}";
+            server.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(body));
+            server.start();
+
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+            SearchChipsResponse response = client.listChips();
+
+            assertEquals(1, response.getChips().size());
+            assertEquals("good-1", response.getChips().get(0).getChipId());
+            assertEquals(List.of("bad-1", "bad-2"), response.getUnreadableChipIds());
+        }
+    }
+
+    @Test
+    void listChipsDefaultsUnreadableChipIdsToEmptyList() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            String body = "{\"chips\":[],\"metadata\":[]}";
+            server.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(body));
+            server.start();
+
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+            SearchChipsResponse response = client.listChips();
+
+            assertNotNull(response.getUnreadableChipIds());
+            assertTrue(response.getUnreadableChipIds().isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds \`unreadableChipIds: List<String>\` to the typed \`SearchChipsResponse\` (returned by listChips, searchChips, and getChip) with the Jackson \`@JsonProperty("unreadable_chip_ids")\` mapping. Defaults to an empty list when the engine doesn't emit the field.
- v1.7.1+ engines always populate it; older engines harmlessly omit it.

## Test plan
- [x] \`mvn test\` — 39/39 pass (new \`UnreadableChipIdsTest\` with populated + empty cases)