### PR TITLE
chore(deps): add Dependabot config with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
Adds a Dependabot config with a 7-day cooldown on every update.

## Why
Defends against supply-chain attacks that ride on freshly-published malicious package versions (the recent SAP / TanStack / PyTorch Lightning / intercom-client wave being the immediate precedent). The cooldown delays the dependabot PR for 7 days after a new release drops, giving the broader community time to detect and report a bad version before we pull it in. New malicious releases are typically yanked within 24-72 hours of disclosure — a 7-day buffer covers nearly all of them.

## Test plan
- [x] YAML lints clean (js-yaml load OK)
- [ ] Dependabot picks up the config and adjusts its scheduling on the next run