### PR TITLE
Throw DatalatheQueryException on failed report queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.4.3</version>
+    <version>1.4.4</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -678,15 +678,40 @@ public class DatalatheClient {
      *
      * @param chipIds                List of chip IDs to query
      * @param queries                List of SQL queries to execute
-     * @param transformQuery         If true, transform queries from MariaDB to
-     *                               DuckDB syntax
+     * @param transformQuery         If true, translate MariaDB-syntax queries
+     *                               for the engine
      * @param returnTransformedQuery If true, include the transformed query in
      *                               results
      * @return GenerateReportResult containing results map and timing metadata
-     * @throws IOException if the API call fails
+     * @throws IOException             if the API call fails
+     * @throws DatalatheQueryException if a query fails at execution time
      */
     public GenerateReportResult generateReport(List<String> chipIds, List<String> queries,
             Boolean transformQuery, Boolean returnTransformedQuery) throws IOException {
+        return generateReport(chipIds, queries, transformQuery, returnTransformedQuery, true);
+    }
+
+    /**
+     * Executes queries against a list of chip IDs, with control over
+     * query-error escalation.
+     *
+     * @param chipIds                List of chip IDs to query
+     * @param queries                List of SQL queries to execute
+     * @param transformQuery         If true, translate MariaDB-syntax queries
+     *                               for the engine
+     * @param returnTransformedQuery If true, include the transformed query in
+     *                               results
+     * @param raiseOnQueryError      If true, throw {@link DatalatheQueryException}
+     *                               when a query fails at execution time; if
+     *                               false, the failure stays on the entry's
+     *                               {@code error} field
+     * @return GenerateReportResult containing results map and timing metadata
+     * @throws IOException             if the API call fails
+     * @throws DatalatheQueryException if a query fails and raiseOnQueryError is true
+     */
+    public GenerateReportResult generateReport(List<String> chipIds, List<String> queries,
+            Boolean transformQuery, Boolean returnTransformedQuery, boolean raiseOnQueryError)
+            throws IOException {
         GenerateReportRequest request = new GenerateReportRequest();
         request.setSourceType(SourceType.CHIP);
         request.setQueryRequest(new GenerateReportRequest.Queries(queries));
@@ -703,6 +728,18 @@ public class DatalatheClient {
                 int idx = Integer.parseInt(entry.getKey());
                 GenerateReportResponse.Result result = entry.getValue();
                 results.put(idx, result);
+            }
+        }
+
+        if (raiseOnQueryError) {
+            Map<Integer, String> queryErrors = new HashMap<>();
+            for (Map.Entry<Integer, GenerateReportResponse.Result> entry : results.entrySet()) {
+                if (entry.getValue().getError() != null) {
+                    queryErrors.put(entry.getKey(), entry.getValue().getError());
+                }
+            }
+            if (!queryErrors.isEmpty()) {
+                throw new DatalatheQueryException(queryErrors);
             }
         }
 

--- a/src/main/java/com/datalathe/client/DatalatheQueryException.java
+++ b/src/main/java/com/datalathe/client/DatalatheQueryException.java
@@ -1,0 +1,44 @@
+package com.datalathe.client;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Thrown by {@code generateReport} when one or more queries fail at execution
+ * time. The engine returns HTTP 200 with the failure in each entry's
+ * {@code error} field; this surfaces it instead of letting a failed query
+ * look like an empty result.
+ *
+ * <p>Pass {@code raiseOnQueryError = false} to {@code generateReport} to
+ * suppress this and inspect {@code GenerateReportResponse.Result.getError()}
+ * on the returned results instead.
+ */
+public class DatalatheQueryException extends IOException {
+    private static final long serialVersionUID = 1L;
+
+    private final Map<Integer, String> errors;
+
+    public DatalatheQueryException(Map<Integer, String> errors) {
+        super(buildMessage(errors));
+        this.errors = errors;
+    }
+
+    /** Failed query index mapped to its execution error message. */
+    public Map<Integer, String> getErrors() {
+        return errors;
+    }
+
+    private static String buildMessage(Map<Integer, String> errors) {
+        StringBuilder sb = new StringBuilder("Query execution failed (");
+        boolean first = true;
+        for (Map.Entry<Integer, String> entry : new TreeMap<>(errors).entrySet()) {
+            if (!first) {
+                sb.append("; ");
+            }
+            sb.append("query ").append(entry.getKey()).append(": ").append(entry.getValue());
+            first = false;
+        }
+        return sb.append(")").toString();
+    }
+}

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -141,12 +141,10 @@ public class DatalatheClientTest {
         }
 
         @Test
-        public void testQueryWithError() throws Exception {
-                // Prepare test data
+        public void testGenerateReportOptOutReturnsErrorEntry() throws Exception {
                 List<String> chipIds = Arrays.asList("chip1");
                 List<String> queries = Arrays.asList("SELECT * FROM users");
 
-                // Mock response with error
                 String responseJson = "{\"result\":{" +
                                 "\"0\":{" +
                                 "\"error\":\"Table not found\"," +
@@ -159,14 +157,64 @@ public class DatalatheClientTest {
                                 .setResponseCode(200)
                                 .setBody(responseJson));
 
-                // Execute test
-                Map<Integer, GenerateReportResponse.Result> results = client.generateReport(chipIds,
-                                queries);
+                Map<Integer, GenerateReportResponse.Result> results = client
+                                .generateReport(chipIds, queries, null, null, false)
+                                .getResults();
 
-                // Verify results - error entry is still included in results map
                 assertEquals(1, results.size());
                 assertEquals("Table not found", results.get(0).getError());
                 assertNull(results.get(0).getResult());
+        }
+
+        @Test
+        public void testGenerateReportRaisesOnFailedQuery() throws Exception {
+                List<String> chipIds = Arrays.asList("chip1");
+                List<String> queries = Arrays.asList("SELECT foo FROM t");
+
+                String responseJson = "{\"result\":{" +
+                                "\"0\":{" +
+                                "\"error\":\"Binder Error: column not found\"," +
+                                "\"result\":null," +
+                                "\"schema\":null" +
+                                "}" +
+                                "}}";
+
+                server.enqueue(new MockResponse()
+                                .setResponseCode(200)
+                                .setBody(responseJson));
+
+                try {
+                        client.generateReport(chipIds, queries);
+                        fail("expected DatalatheQueryException");
+                } catch (DatalatheQueryException e) {
+                        assertEquals(1, e.getErrors().size());
+                        assertEquals("Binder Error: column not found", e.getErrors().get(0));
+                }
+        }
+
+        @Test
+        public void testGenerateReportReportsEveryFailedQuery() throws Exception {
+                List<String> chipIds = Arrays.asList("chip1");
+                List<String> queries = Arrays.asList("SELECT 1", "SELECT bad", "SELECT worse");
+
+                String responseJson = "{\"result\":{" +
+                                "\"0\":{\"error\":null,\"result\":[[\"1\"]],\"schema\":null}," +
+                                "\"1\":{\"error\":\"bad query\",\"result\":null,\"schema\":null}," +
+                                "\"2\":{\"error\":\"worse query\",\"result\":null,\"schema\":null}" +
+                                "}}";
+
+                server.enqueue(new MockResponse()
+                                .setResponseCode(200)
+                                .setBody(responseJson));
+
+                try {
+                        client.generateReport(chipIds, queries);
+                        fail("expected DatalatheQueryException");
+                } catch (DatalatheQueryException e) {
+                        assertEquals(2, e.getErrors().size());
+                        assertEquals("bad query", e.getErrors().get(1));
+                        assertEquals("worse query", e.getErrors().get(2));
+                }
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Adds `DatalatheQueryException` (extends `IOException`, matching `ChipNotFoundException`), carrying a `getErrors()` map of failed-query index → message.
- `generateReport` throws it when any query fails at execution time. A new 5-arg overload takes `raiseOnQueryError`; the existing overloads default it to `true`. Pass `false` to inspect each entry's `error` field instead.
- Mirrors the feature already shipped in the Python (`datalathe` 1.2.3) and JavaScript clients.

## Behavior change
`generateReport` previously returned failed queries as empty result entries. It now raises by default. Callers that want the old behavior use the 5-arg overload with `raiseOnQueryError = false`.

## Test plan
- [x] `mvn test` — 41 pass (raises on failure, reports every failed query, opt-out returns the entry)