### PR TITLE
Rename partitionColumn to keysetColumn; add partition to S3 creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -342,7 +342,7 @@ public class DatalatheClient {
      * @throws IOException if the API call fails
      */
     public String createChipFromS3(String s3Path, String tableName) throws IOException {
-        return createChipFromS3(s3Path, tableName, null, null);
+        return createChipFromS3(s3Path, tableName, null, null, null);
     }
 
     /**
@@ -358,11 +358,31 @@ public class DatalatheClient {
     public String createChipFromS3(String s3Path, String tableName,
             Map<String, String> columnReplace,
             S3StorageConfig storageConfig) throws IOException {
+        return createChipFromS3(s3Path, tableName, null, columnReplace, storageConfig);
+    }
+
+    /**
+     * Creates a new chip from an S3 object, optionally partitioned by a column.
+     *
+     * @param s3Path        S3 URI (e.g. s3://bucket/path/file.csv)
+     * @param tableName     Optional table name for the chip
+     * @param partition     Optional partition configuration — splits the object
+     *                      into one sub-chip per distinct value of a column
+     * @param columnReplace Optional column renaming map
+     * @param storageConfig Optional S3 storage configuration for the created chip
+     * @return The chip ID
+     * @throws IOException if the API call fails
+     */
+    public String createChipFromS3(String s3Path, String tableName,
+            ChipSource.Partition partition,
+            Map<String, String> columnReplace,
+            S3StorageConfig storageConfig) throws IOException {
         CreateChipRequest request = new CreateChipRequest();
         request.setSourceType(SourceType.S3);
         request.setSource(ChipSource.builder()
                 .s3Path(s3Path)
                 .tableName(tableName)
+                .partition(partition)
                 .columnReplace(columnReplace)
                 .build());
         request.setStorageConfig(storageConfig);

--- a/src/main/java/com/datalathe/client/SearchChipsResponse.java
+++ b/src/main/java/com/datalathe/client/SearchChipsResponse.java
@@ -51,6 +51,8 @@ public class SearchChipsResponse {
         private String storageKeyPrefix;
         @JsonProperty("ttl_days")
         private Long ttlDays;
+        @JsonProperty("partition_column")
+        private String partitionColumn;
     }
 
     @Data

--- a/src/main/java/com/datalathe/client/types/ChipSource.java
+++ b/src/main/java/com/datalathe/client/types/ChipSource.java
@@ -66,8 +66,8 @@ public class ChipSource {
      * Only meaningful when {@link #streaming} is {@code true}.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("partition_column")
-    private String partitionColumn;
+    @JsonProperty("keyset_column")
+    private String keysetColumn;
 
     public ChipSource(String databaseName, String tableName, String query) {
         this.databaseName = databaseName;

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -617,4 +617,17 @@ public class DatalatheClientTest {
                 assertEquals(200000000L, (long) response.getTotalRows());
                 assertEquals(1843121L, (long) response.getElapsedMs());
         }
+
+        @Test
+        public void testChipMetadataPartitionColumnDeserialized() throws Exception {
+                ObjectMapper mapper = new ObjectMapper();
+                String json = "{\"chips\":[],\"metadata\":[{"
+                                + "\"chip_id\":\"chip1\",\"created_at\":1700000000,"
+                                + "\"description\":\"d\",\"name\":\"n\","
+                                + "\"partition_column\":\"country\"}]}";
+
+                SearchChipsResponse response = mapper.readValue(json, SearchChipsResponse.class);
+
+                assertEquals("country", response.getMetadata().get(0).getPartitionColumn());
+        }
 }

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -578,15 +578,31 @@ public class DatalatheClientTest {
                                 .tableName("events")
                                 .query("SELECT * FROM events")
                                 .streaming(true)
-                                .partitionColumn("id")
+                                .keysetColumn("id")
                                 .build();
 
                 client.createChip(source);
 
                 String body = server.takeRequest().getBody().readUtf8();
                 assertTrue("streaming field must be serialized", body.contains("\"streaming\":true"));
-                assertTrue("partition_column field must be serialized",
-                                body.contains("\"partition_column\":\"id\""));
+                assertTrue("keyset_column field must be serialized",
+                                body.contains("\"keyset_column\":\"id\""));
+        }
+
+        @Test
+        public void testCreateChipFromS3SerializesPartition() throws Exception {
+                server.enqueue(new MockResponse()
+                                .setResponseCode(200)
+                                .setBody("{\"chip_id\":\"chip-s3-part\",\"error\":null}"));
+
+                client.createChipFromS3("s3://bucket/data.parquet", "sales",
+                                new ChipSource.Partition("region"), null, null);
+
+                String body = server.takeRequest().getBody().readUtf8();
+                assertTrue("s3_path must be serialized",
+                                body.contains("\"s3_path\":\"s3://bucket/data.parquet\""));
+                assertTrue("partition_by must be serialized",
+                                body.contains("\"partition_by\":\"region\""));
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Renames `ChipSource.partitionColumn` → `keysetColumn` (wire field `partition_column` → `keyset_column`), matching the backend. **Breaking at the API level** — the field is days old, so no deprecation shim.
- Adds a `createChipFromS3` overload accepting a `Partition`, making partitioned staging reachable for S3 sources.
- Bumps to 1.5.0.

## Test plan
- [x] `mvn test` — 21 tests pass, including new tests for `keyset_column` serialization and S3 partition forwarding