### PR TITLE
Release 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/types/AgentOptions.java
+++ b/src/main/java/com/datalathe/client/types/AgentOptions.java
@@ -40,4 +40,8 @@ public class AgentOptions {
     /** Abort once cumulative input token usage exceeds this (hard cap). */
     @JsonProperty("max_total_input_tokens")
     private Integer maxTotalInputTokens;
+
+    /** Ask the model for up to 3 suggested follow-up questions (default on). */
+    @JsonProperty("suggest_follow_ups")
+    private Boolean suggestFollowUps;
 }

--- a/src/main/java/com/datalathe/client/types/AgentResponse.java
+++ b/src/main/java/com/datalathe/client/types/AgentResponse.java
@@ -40,6 +40,9 @@ public class AgentResponse {
     @JsonProperty("narration")
     private List<NarrationEntry> narration;
 
+    @JsonProperty("follow_ups")
+    private List<String> followUps = List.of();
+
     @JsonProperty("session_id")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String sessionId;

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -529,6 +529,75 @@ public class DatalatheClientTest {
         }
 
         @Test
+        public void testAiAgentParsesFollowUps() throws Exception {
+                server.enqueue(new MockResponse().setResponseCode(200).setBody(
+                                "{\"request_id\":\"r\",\"answer\":\"ok\","
+                                                + "\"attachments\":[],\"tool_calls\":[],\"narration\":[],"
+                                                + "\"follow_ups\":[\"How did Q2 compare?\","
+                                                + "\"Which region drove the change?\"]}"));
+
+                AgentResponse result = client.aiAgent(AgentRequest.builder()
+                                .contextId("ctx1")
+                                .userQuestion("Q")
+                                .build());
+
+                assertEquals(Arrays.asList("How did Q2 compare?", "Which region drove the change?"),
+                                result.getFollowUps());
+        }
+
+        @Test
+        public void testAiAgentFollowUpsEmptyWhenAbsent() throws Exception {
+                server.enqueue(new MockResponse().setResponseCode(200).setBody(
+                                "{\"request_id\":\"r\",\"answer\":\"ok\","
+                                                + "\"attachments\":[],\"tool_calls\":[],\"narration\":[]}"));
+
+                AgentResponse result = client.aiAgent(AgentRequest.builder()
+                                .contextId("ctx1")
+                                .userQuestion("Q")
+                                .build());
+
+                assertNotNull(result.getFollowUps());
+                assertTrue(result.getFollowUps().isEmpty());
+        }
+
+        @Test
+        public void testAiAgentSerializesSuggestFollowUpsFalse() throws Exception {
+                server.enqueue(new MockResponse().setResponseCode(200).setBody(
+                                "{\"request_id\":\"r\",\"answer\":\"ok\","
+                                                + "\"attachments\":[],\"tool_calls\":[],\"narration\":[]}"));
+
+                client.aiAgent(AgentRequest.builder()
+                                .contextId("ctx1")
+                                .userQuestion("Q")
+                                .agentOptions(AgentOptions.builder()
+                                                .suggestFollowUps(false)
+                                                .build())
+                                .build());
+
+                String body = server.takeRequest().getBody().readUtf8();
+                assertTrue(body.contains("\"suggest_follow_ups\":false"));
+        }
+
+        @Test
+        public void testAiAgentOmitsSuggestFollowUpsWhenUnset() throws Exception {
+                server.enqueue(new MockResponse().setResponseCode(200).setBody(
+                                "{\"request_id\":\"r\",\"answer\":\"ok\","
+                                                + "\"attachments\":[],\"tool_calls\":[],\"narration\":[]}"));
+
+                client.aiAgent(AgentRequest.builder()
+                                .contextId("ctx1")
+                                .userQuestion("Q")
+                                .agentOptions(AgentOptions.builder()
+                                                .maxIterations(3)
+                                                .build())
+                                .build());
+
+                String body = server.takeRequest().getBody().readUtf8();
+                assertTrue(body.contains("\"max_iterations\":3"));
+                assertFalse(body.contains("suggest_follow_ups"));
+        }
+
+        @Test
         public void testAiAgentSurfacesChipNotFoundOn404() throws Exception {
                 server.enqueue(new MockResponse()
                                 .setResponseCode(404)


### PR DESCRIPTION
## Summary
- `AgentResponse.getFollowUps()` — model-suggested next questions from engine 1.7.10+, empty list when absent
- `AgentOptions.suggestFollowUps` — serializes as `suggest_follow_ups`

## Test plan
- [x] 47 tests pass (4 new)