### PR TITLE
Add timeout to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
   publish:
     name: Build, sign, and deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
30-minute job timeout (Central Portal's waitUntil=published can stall) so a hung publish fails fast instead of holding the 6-hour Actions default.