### PR TITLE
1.7.0: async ingest jobs, chip list pagination, truncated flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -435,6 +436,142 @@ public class DatalatheClient {
         return response.getChipId();
     }
 
+    // --- Async ingest ---
+
+    /**
+     * Submits a chip-creating ingest to run asynchronously. Returns as soon
+     * as the engine accepts the job; use {@link #waitForIngest} or
+     * {@link #getIngestJob} to track progress.
+     *
+     * @param source The fully configured source
+     * @return A handle with the job ID and the chip ID being created
+     * @throws IOException              if the API call fails (400 when the
+     *                                  engine has no chip-manager configured,
+     *                                  429 when the job queue is full)
+     * @throws IllegalArgumentException if sourceType is not set on the source
+     */
+    public IngestJobHandle createChipAsync(ChipSource source) throws IOException {
+        return createChipAsync(source, null);
+    }
+
+    /**
+     * Submits an asynchronous chip-creating ingest with an optional chip ID.
+     *
+     * @param source The fully configured source
+     * @param chipId Optional chip ID to use
+     * @return A handle with the job ID and the chip ID being created
+     * @throws IOException              if the API call fails
+     * @throws IllegalArgumentException if sourceType is not set on the source
+     */
+    public IngestJobHandle createChipAsync(ChipSource source, String chipId) throws IOException {
+        return createChipAsync(source, chipId, null);
+    }
+
+    /**
+     * Submits an asynchronous chip-creating ingest with optional chip ID and
+     * tags. Tags are applied atomically with chip creation.
+     *
+     * @param source The fully configured source
+     * @param chipId Optional chip ID to use
+     * @param tags   Optional tags to apply atomically with creation
+     * @return A handle with the job ID and the chip ID being created
+     * @throws IOException              if the API call fails
+     * @throws IllegalArgumentException if sourceType is not set on the source
+     */
+    public IngestJobHandle createChipAsync(ChipSource source, String chipId, Map<String, String> tags)
+            throws IOException {
+        if (source.getSourceType() == null) {
+            throw new IllegalArgumentException("sourceType must be set on the Source");
+        }
+        CreateChipRequest request = new CreateChipRequest();
+        request.setSourceType(source.getSourceType());
+        request.setSource(source);
+        request.setChipId(chipId);
+        request.setStorageConfig(source.getStorageConfig());
+        request.setTags(tags);
+        request.setAsync(true);
+        return post("/lathe/stage/data", request, IngestJobHandle.class);
+    }
+
+    /**
+     * Fetches the current status of an asynchronous ingest job.
+     *
+     * @param jobId The job ID returned by {@link #createChipAsync}
+     * @return The job status record
+     * @throws IOException if the API call fails
+     */
+    public IngestJob getIngestJob(String jobId) throws IOException {
+        return get("/lathe/jobs/" + URLEncoder.encode(jobId, StandardCharsets.UTF_8), IngestJob.class);
+    }
+
+    /**
+     * Lists all asynchronous ingest jobs.
+     */
+    public List<IngestJob> listIngestJobs() throws IOException {
+        return listIngestJobs(null);
+    }
+
+    /**
+     * Lists asynchronous ingest jobs, optionally filtered by status.
+     *
+     * @param status Optional status filter — one of {@code queued},
+     *               {@code running}, {@code succeeded}, {@code failed},
+     *               {@code cancelled}
+     * @return The matching jobs
+     * @throws IOException if the API call fails
+     */
+    public List<IngestJob> listIngestJobs(String status) throws IOException {
+        String path = "/lathe/jobs";
+        if (status != null) {
+            path += "?status=" + URLEncoder.encode(status, StandardCharsets.UTF_8);
+        }
+        return Arrays.asList(get(path, IngestJob[].class));
+    }
+
+    /**
+     * Resumes a failed ingest job from its last committed chunk.
+     *
+     * @param jobId The job ID to resume
+     * @return A handle with the job ID and chip ID
+     * @throws IOException if the API call fails (409 when the job is still
+     *                     running, 422 when it is not resumable)
+     */
+    public IngestJobHandle resumeIngestJob(String jobId) throws IOException {
+        return post("/lathe/jobs/" + URLEncoder.encode(jobId, StandardCharsets.UTF_8) + "/resume",
+                new HashMap<>(), IngestJobHandle.class);
+    }
+
+    /**
+     * Polls an asynchronous ingest job until it reaches a terminal state.
+     *
+     * @param jobId        The job ID returned by {@link #createChipAsync}
+     * @param pollInterval How long to wait between status checks
+     * @param timeout      Maximum total time to wait
+     * @return The final job record when the job succeeds
+     * @throws IngestFailedException if the job ends {@code failed} or
+     *                               {@code cancelled}; carries the job's error
+     * @throws IOException           if polling fails or the timeout elapses
+     * @throws InterruptedException  if the polling thread is interrupted
+     */
+    public IngestJob waitForIngest(String jobId, Duration pollInterval, Duration timeout)
+            throws IOException, InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (true) {
+            IngestJob job = getIngestJob(jobId);
+            IngestJobStatus status = job.getStatus();
+            if (status == IngestJobStatus.SUCCEEDED) {
+                return job;
+            }
+            if (status != null && status.isTerminal()) {
+                throw new IngestFailedException(jobId, status, job.getError());
+            }
+            if (System.nanoTime() >= deadline) {
+                throw new IOException("Timed out waiting for ingest job " + jobId + " after " + timeout);
+            }
+            Thread.sleep(pollInterval.toMillis());
+        }
+    }
+
     /**
      * Deletes a chip and its associated data (local files and S3 objects).
      *
@@ -508,7 +645,27 @@ public class DatalatheClient {
      * Returns all chips and their metadata.
      */
     public SearchChipsResponse listChips() throws IOException {
-        return get("/lathe/chips", SearchChipsResponse.class);
+        return listChips(null, null);
+    }
+
+    /**
+     * Returns a page of chips and their metadata.
+     *
+     * @param limit  Maximum number of chips to return, or null for no limit
+     * @param offset Number of chips to skip, or null to start from the beginning
+     * @return The page of chips; {@code totalCount} carries the unpaged total
+     * @throws IOException if the API call fails
+     */
+    public SearchChipsResponse listChips(Integer limit, Integer offset) throws IOException {
+        List<String> params = new ArrayList<>();
+        if (limit != null) {
+            params.add("limit=" + limit);
+        }
+        if (offset != null) {
+            params.add("offset=" + offset);
+        }
+        String path = "/lathe/chips" + (params.isEmpty() ? "" : "?" + String.join("&", params));
+        return get(path, SearchChipsResponse.class);
     }
 
     /**

--- a/src/main/java/com/datalathe/client/IngestFailedException.java
+++ b/src/main/java/com/datalathe/client/IngestFailedException.java
@@ -1,0 +1,41 @@
+package com.datalathe.client;
+
+import com.datalathe.client.types.IngestJobStatus;
+
+import java.io.IOException;
+
+/**
+ * Thrown when an asynchronous ingest job reaches a terminal failure state
+ * ({@code failed} or {@code cancelled}).
+ *
+ * <p>Recovery pattern: inspect {@link #getJobError()}; for resumable
+ * failures call {@code resumeIngestJob} with the same job ID and wait
+ * again.
+ */
+public class IngestFailedException extends IOException {
+    private static final long serialVersionUID = 1L;
+
+    private final String jobId;
+    private final IngestJobStatus status;
+    private final String jobError;
+
+    public IngestFailedException(String jobId, IngestJobStatus status, String jobError) {
+        super("Ingest job " + jobId + " " + (status != null ? status.name().toLowerCase() : "failed")
+                + (jobError != null ? ": " + jobError : ""));
+        this.jobId = jobId;
+        this.status = status;
+        this.jobError = jobError;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public IngestJobStatus getStatus() {
+        return status;
+    }
+
+    public String getJobError() {
+        return jobError;
+    }
+}

--- a/src/main/java/com/datalathe/client/SearchChipsResponse.java
+++ b/src/main/java/com/datalathe/client/SearchChipsResponse.java
@@ -74,4 +74,13 @@ public class SearchChipsResponse {
      */
     @JsonProperty("unreadable_chip_ids")
     private List<String> unreadableChipIds = new ArrayList<>();
+
+    /**
+     * Total number of chips matching the request, regardless of any
+     * {@code limit}/{@code offset} applied. Populated by v1.7.12+ engines
+     * on the list endpoint; null on older engines or endpoints that don't
+     * emit the field.
+     */
+    @JsonProperty("total_count")
+    private Long totalCount;
 }

--- a/src/main/java/com/datalathe/client/types/AiQueryResponse.java
+++ b/src/main/java/com/datalathe/client/types/AiQueryResponse.java
@@ -69,6 +69,10 @@ public class AiQueryResponse {
 
         @JsonProperty("rows")
         private List<List<String>> rows;
+
+        /** True when rows were cut off at the engine's result-row cap. */
+        @JsonProperty("truncated")
+        private boolean truncated;
     }
 
     @Data

--- a/src/main/java/com/datalathe/client/types/CreateChipRequest.java
+++ b/src/main/java/com/datalathe/client/types/CreateChipRequest.java
@@ -30,6 +30,10 @@ public class CreateChipRequest {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Map<String, String> tags;
 
+    @JsonProperty("async")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean async;
+
     public CreateChipRequest(SourceType sourceType, ChipSource source) {
         this.sourceType = sourceType;
         this.source = source;

--- a/src/main/java/com/datalathe/client/types/IngestJob.java
+++ b/src/main/java/com/datalathe/client/types/IngestJob.java
@@ -1,0 +1,42 @@
+package com.datalathe.client.types;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Status record for an asynchronous ingest job. All fields except
+ * {@code jobId} and {@code status} may be null.
+ */
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IngestJob {
+    @JsonProperty("job_id")
+    private String jobId;
+
+    @JsonProperty("chip_id")
+    private String chipId;
+
+    @JsonProperty("status")
+    private IngestJobStatus status;
+
+    @JsonProperty("rows_ingested")
+    private Long rowsIngested;
+
+    @JsonProperty("chunks_done")
+    private Integer chunksDone;
+
+    @JsonProperty("chunks_total")
+    private Integer chunksTotal;
+
+    @JsonProperty("error")
+    private String error;
+
+    @JsonProperty("created_at")
+    private Long createdAt;
+
+    @JsonProperty("updated_at")
+    private Long updatedAt;
+}

--- a/src/main/java/com/datalathe/client/types/IngestJobHandle.java
+++ b/src/main/java/com/datalathe/client/types/IngestJobHandle.java
@@ -1,0 +1,22 @@
+package com.datalathe.client.types;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Returned when an asynchronous ingest is accepted (HTTP 202). Use the
+ * job ID with {@code getIngestJob} / {@code waitForIngest} to track
+ * progress; the chip ID identifies the chip being created.
+ */
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IngestJobHandle {
+    @JsonProperty("job_id")
+    private String jobId;
+
+    @JsonProperty("chip_id")
+    private String chipId;
+}

--- a/src/main/java/com/datalathe/client/types/IngestJobStatus.java
+++ b/src/main/java/com/datalathe/client/types/IngestJobStatus.java
@@ -1,0 +1,22 @@
+package com.datalathe.client.types;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Lifecycle state of an asynchronous ingest job.
+ */
+public enum IngestJobStatus {
+    @JsonProperty("queued") QUEUED,
+    @JsonProperty("running") RUNNING,
+    @JsonProperty("succeeded") SUCCEEDED,
+    @JsonProperty("failed") FAILED,
+    @JsonProperty("cancelled") CANCELLED;
+
+    /**
+     * True when the job will make no further progress
+     * (succeeded, failed, or cancelled).
+     */
+    public boolean isTerminal() {
+        return this == SUCCEEDED || this == FAILED || this == CANCELLED;
+    }
+}

--- a/src/test/java/com/datalathe/client/DatalatheClientTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheClientTest.java
@@ -312,6 +312,28 @@ public class DatalatheClientTest {
         }
 
         @Test
+        public void testAiQueryParsesTruncatedResultData() throws Exception {
+                String responseJson = "{" +
+                        "\"request_id\":\"req1\"," +
+                        "\"data\":{" +
+                        "\"columns\":[{\"name\":\"id\",\"data_type\":\"Int32\"}]," +
+                        "\"rows\":[[\"1\"],[\"2\"]]," +
+                        "\"truncated\":true" +
+                        "}" +
+                        "}";
+
+                server.enqueue(new MockResponse()
+                                .setResponseCode(200)
+                                .setBody(responseJson));
+
+                AiQueryResponse result = client.aiQuery("ctx1", "cred1", "List ids");
+
+                assertNotNull(result.getData());
+                assertTrue(result.getData().isTruncated());
+                assertEquals(2, result.getData().getRows().size());
+        }
+
+        @Test
         public void testAiConversation() throws Exception {
                 String response1Json = "{" +
                         "\"request_id\":\"req1\"," +

--- a/src/test/java/com/datalathe/client/IngestJobsTest.java
+++ b/src/test/java/com/datalathe/client/IngestJobsTest.java
@@ -1,0 +1,199 @@
+package com.datalathe.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datalathe.client.types.ChipSource;
+import com.datalathe.client.types.IngestJob;
+import com.datalathe.client.types.IngestJobHandle;
+import com.datalathe.client.types.IngestJobStatus;
+import com.datalathe.client.types.SourceType;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IngestJobsTest {
+
+    private MockWebServer server;
+    private DatalatheClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        client = new DatalatheClient(server.url("/").toString().replaceAll("/$", ""));
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    private void enqueueJson(int code, String body) {
+        server.enqueue(new MockResponse()
+                .setResponseCode(code)
+                .setHeader("Content-Type", "application/json")
+                .setBody(body));
+    }
+
+    private static String jobBody(String status, String error) {
+        return "{\"job_id\":\"job-1\",\"chip_id\":\"chip-1\",\"status\":\"" + status + "\","
+                + "\"rows_ingested\":500,\"chunks_done\":5,\"chunks_total\":10,"
+                + "\"error\":" + (error == null ? "null" : "\"" + error + "\"") + ","
+                + "\"created_at\":1700000000,\"updated_at\":1700000100}";
+    }
+
+    @Test
+    void createChipAsyncSubmitsJobAndReturnsHandle() throws Exception {
+        enqueueJson(202, "{\"job_id\":\"job-1\",\"chip_id\":\"chip-1\"}");
+
+        ChipSource source = ChipSource.builder()
+                .sourceType(SourceType.MYSQL)
+                .databaseName("test_db")
+                .tableName("users")
+                .query("SELECT * FROM users")
+                .build();
+        IngestJobHandle handle = client.createChipAsync(source);
+
+        assertEquals("job-1", handle.getJobId());
+        assertEquals("chip-1", handle.getChipId());
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("/lathe/stage/data", request.getPath());
+        String body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"async\":true"));
+        assertTrue(body.contains("\"source_type\":\"MYSQL\""));
+        assertTrue(body.contains("\"table_name\":\"users\""));
+    }
+
+    @Test
+    void createChipAsyncRejectsSourceWithoutSourceType() {
+        ChipSource source = ChipSource.builder().tableName("users").build();
+        assertThrows(IllegalArgumentException.class, () -> client.createChipAsync(source));
+    }
+
+    @Test
+    void createChipSyncRequestOmitsAsyncFlag() throws Exception {
+        enqueueJson(200, "{\"chip_id\":\"chip-1\",\"error\":null}");
+
+        client.createChip("test_db", "SELECT * FROM users", "users");
+
+        String body = server.takeRequest().getBody().readUtf8();
+        assertTrue(!body.contains("\"async\""));
+    }
+
+    @Test
+    void getIngestJobParsesFullRecord() throws Exception {
+        enqueueJson(200, jobBody("running", null));
+
+        IngestJob job = client.getIngestJob("job-1");
+
+        assertEquals("/lathe/jobs/job-1", server.takeRequest().getPath());
+        assertEquals("job-1", job.getJobId());
+        assertEquals("chip-1", job.getChipId());
+        assertEquals(IngestJobStatus.RUNNING, job.getStatus());
+        assertEquals(Long.valueOf(500), job.getRowsIngested());
+        assertEquals(Integer.valueOf(5), job.getChunksDone());
+        assertEquals(Integer.valueOf(10), job.getChunksTotal());
+        assertNull(job.getError());
+        assertEquals(Long.valueOf(1700000000L), job.getCreatedAt());
+        assertEquals(Long.valueOf(1700000100L), job.getUpdatedAt());
+    }
+
+    @Test
+    void listIngestJobsSendsStatusFilter() throws Exception {
+        enqueueJson(200, "[" + jobBody("failed", "boom") + "]");
+
+        List<IngestJob> jobs = client.listIngestJobs("failed");
+
+        assertEquals("/lathe/jobs?status=failed", server.takeRequest().getPath());
+        assertEquals(1, jobs.size());
+        assertEquals(IngestJobStatus.FAILED, jobs.get(0).getStatus());
+        assertEquals("boom", jobs.get(0).getError());
+    }
+
+    @Test
+    void listIngestJobsWithoutFilterKeepsBarePath() throws Exception {
+        enqueueJson(200, "[]");
+
+        List<IngestJob> jobs = client.listIngestJobs();
+
+        assertEquals("/lathe/jobs", server.takeRequest().getPath());
+        assertTrue(jobs.isEmpty());
+    }
+
+    @Test
+    void resumeIngestJobPostsToResumeEndpoint() throws Exception {
+        enqueueJson(202, "{\"job_id\":\"job-1\",\"chip_id\":\"chip-1\"}");
+
+        IngestJobHandle handle = client.resumeIngestJob("job-1");
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("POST", request.getMethod());
+        assertEquals("/lathe/jobs/job-1/resume", request.getPath());
+        assertEquals("job-1", handle.getJobId());
+    }
+
+    @Test
+    void resumeIngestJobSurfacesConflict() {
+        enqueueJson(409, "{\"error\":\"job is still running\"}");
+
+        IOException e = assertThrows(IOException.class, () -> client.resumeIngestJob("job-1"));
+        assertTrue(e.getMessage().contains("409"));
+    }
+
+    @Test
+    void waitForIngestPollsUntilSucceeded() throws Exception {
+        enqueueJson(200, jobBody("queued", null));
+        enqueueJson(200, jobBody("running", null));
+        enqueueJson(200, jobBody("succeeded", null));
+
+        IngestJob job = client.waitForIngest("job-1", Duration.ofMillis(10), Duration.ofSeconds(5));
+
+        assertEquals(IngestJobStatus.SUCCEEDED, job.getStatus());
+        assertEquals(Long.valueOf(500), job.getRowsIngested());
+        assertEquals(3, server.getRequestCount());
+    }
+
+    @Test
+    void waitForIngestThrowsTypedExceptionOnFailure() {
+        enqueueJson(200, jobBody("failed", "source connection lost"));
+
+        IngestFailedException e = assertThrows(IngestFailedException.class,
+                () -> client.waitForIngest("job-1", Duration.ofMillis(10), Duration.ofSeconds(5)));
+
+        assertEquals("job-1", e.getJobId());
+        assertEquals(IngestJobStatus.FAILED, e.getStatus());
+        assertEquals("source connection lost", e.getJobError());
+        assertTrue(e.getMessage().contains("source connection lost"));
+    }
+
+    @Test
+    void waitForIngestThrowsTypedExceptionOnCancelled() {
+        enqueueJson(200, jobBody("cancelled", null));
+
+        IngestFailedException e = assertThrows(IngestFailedException.class,
+                () -> client.waitForIngest("job-1", Duration.ofMillis(10), Duration.ofSeconds(5)));
+
+        assertEquals(IngestJobStatus.CANCELLED, e.getStatus());
+        assertNull(e.getJobError());
+    }
+
+    @Test
+    void waitForIngestThrowsOnTimeout() {
+        enqueueJson(200, jobBody("running", null));
+
+        IOException e = assertThrows(IOException.class,
+                () -> client.waitForIngest("job-1", Duration.ofMillis(10), Duration.ZERO));
+
+        assertTrue(e.getMessage().contains("Timed out waiting for ingest job job-1"));
+    }
+}

--- a/src/test/java/com/datalathe/client/ListChipsPaginationTest.java
+++ b/src/test/java/com/datalathe/client/ListChipsPaginationTest.java
@@ -1,0 +1,75 @@
+package com.datalathe.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.Test;
+
+class ListChipsPaginationTest {
+
+    private static final String PAGE_BODY = "{"
+            + "\"chips\":[{\"chip_id\":\"chip-1\",\"sub_chip_id\":\"sub-1\","
+            + "\"table_name\":\"users\",\"partition_value\":\"default\"}],"
+            + "\"metadata\":[],"
+            + "\"unreadable_chip_ids\":[\"bad-1\"],"
+            + "\"total_count\":42}";
+
+    @Test
+    void listChipsSendsLimitAndOffset() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(PAGE_BODY));
+            server.start();
+
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+            SearchChipsResponse response = client.listChips(10, 20);
+
+            RecordedRequest request = server.takeRequest();
+            assertEquals("/lathe/chips?limit=10&offset=20", request.getPath());
+            assertEquals(1, response.getChips().size());
+            assertEquals(Long.valueOf(42), response.getTotalCount());
+            assertEquals(1, response.getUnreadableChipIds().size());
+        }
+    }
+
+    @Test
+    void listChipsSendsOnlyProvidedParams() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(PAGE_BODY));
+            server.start();
+
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+            client.listChips(5, null);
+
+            assertEquals("/lathe/chips?limit=5", server.takeRequest().getPath());
+        }
+    }
+
+    @Test
+    void listChipsWithoutPaginationKeepsBarePath() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody("{\"chips\":[],\"metadata\":[]}"));
+            server.start();
+
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+            SearchChipsResponse response = client.listChips();
+
+            assertEquals("/lathe/chips", server.takeRequest().getPath());
+            assertNull(response.getTotalCount());
+        }
+    }
+}


### PR DESCRIPTION
Additive surface for engine 1.7.12: `createChipAsync` overloads (202 + `IngestJobHandle`), `getIngestJob`/`listIngestJobs`/`resumeIngestJob`, `waitForIngest(Duration, Duration)` (typed `IngestFailedException`), `listChips(limit, offset)` + `totalCount`, `truncated` on AI result data. Sync request bodies byte-identical (NON_NULL async flag, test-pinned). 63 tests, BUILD SUCCESS (gpg skipped locally; CI signs on tag). Publish via v1.7.0 tag after backend 1.7.12 ships.