### PR TITLE
Streaming report results (DatalatheStreamingResultSet, JDBC forward-only) — v1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>

--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -1,5 +1,6 @@
 package com.datalathe.client;
 
+import com.datalathe.client.results.DatalatheStreamingResultSet;
 import com.datalathe.client.types.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -921,6 +922,107 @@ public class DatalatheClient {
         }
 
         return new GenerateReportResult(results, response.getTiming());
+    }
+
+    /**
+     * Executes a single query against a list of chip IDs and streams the result
+     * rows back incrementally over an NDJSON response, rather than buffering the
+     * whole result in memory.
+     *
+     * <p>The returned {@link DatalatheStreamingResultSet} is forward-only
+     * ({@link java.sql.ResultSet#TYPE_FORWARD_ONLY}); iterate it with
+     * {@code while (rs.next()) { ... }}. It owns the live HTTP connection, so it
+     * must be closed when done — use try-with-resources. Unlike the buffered
+     * path, the server applies no {@code max_result_rows} cap to streamed
+     * responses, so a partial download is the caller's memory concern.</p>
+     *
+     * <p>Only a single query is supported; the engine rejects multi-query
+     * streaming with a 400, so this method rejects it client-side with an
+     * {@link IllegalArgumentException}.</p>
+     *
+     * @param chipIds List of chip IDs to query
+     * @param query   The single SQL query to execute
+     * @return a forward-only streaming result set over the query's rows
+     * @throws IOException              if the request fails before the first
+     *                                  frame (4xx/5xx, including chip-not-found)
+     * @throws IllegalArgumentException if more than one query is supplied
+     */
+    public DatalatheStreamingResultSet generateReportStream(List<String> chipIds, String query)
+            throws IOException {
+        return generateReportStream(chipIds, query, null, null);
+    }
+
+    /**
+     * Streaming counterpart to {@link #generateReport}, with transform-query
+     * support.
+     *
+     * @param chipIds                List of chip IDs to query
+     * @param query                  The single SQL query to execute
+     * @param transformQuery         If true, translate MariaDB-syntax queries
+     *                               for the engine
+     * @param returnTransformedQuery If true, the schema frame carries the
+     *                               transformed query
+     *                               ({@link DatalatheStreamingResultSet#getTransformedQuery()})
+     * @return a forward-only streaming result set over the query's rows
+     * @throws IOException              if the request fails before the first frame
+     * @throws IllegalArgumentException if more than one query is supplied
+     */
+    public DatalatheStreamingResultSet generateReportStream(List<String> chipIds, String query,
+            Boolean transformQuery, Boolean returnTransformedQuery) throws IOException {
+        if (query == null) {
+            throw new IllegalArgumentException("query must not be null");
+        }
+
+        GenerateReportRequest request = new GenerateReportRequest();
+        request.setSourceType(SourceType.CHIP);
+        request.setQueryRequest(new GenerateReportRequest.Queries(List.of(query)));
+        request.setChipIds(chipIds);
+        request.setTransformQuery(transformQuery);
+        request.setReturnTransformedQuery(returnTransformedQuery);
+        request.setStream(true);
+
+        Request httpRequest = new Request.Builder()
+                .url(baseUrl + "/lathe/report")
+                .header("Accept", "application/x-ndjson")
+                .post(RequestBody.create(objectMapper.writeValueAsString(request), JSON))
+                .build();
+
+        Response response = client.newCall(httpRequest).execute();
+        if (!response.isSuccessful()) {
+            String responseBody;
+            try (Response r = response) {
+                responseBody = r.body() != null ? r.body().string() : "";
+            }
+            throwForFailure("POST", "/lathe/report", response.code(), responseBody);
+        }
+
+        try {
+            return new DatalatheStreamingResultSet(response);
+        } catch (java.sql.SQLException e) {
+            response.close();
+            throw new IOException("Failed to open streaming report", e);
+        }
+    }
+
+    /**
+     * Convenience overload of {@link #generateReportStream(List, String)} that
+     * rejects a multi-query list client-side, mirroring the engine's 400 for
+     * streaming with more than one query.
+     *
+     * @param chipIds List of chip IDs to query
+     * @param queries The queries; must contain exactly one entry
+     * @return a forward-only streaming result set over the query's rows
+     * @throws IOException              if the request fails before the first frame
+     * @throws IllegalArgumentException if {@code queries} is not exactly one query
+     */
+    public DatalatheStreamingResultSet generateReportStream(List<String> chipIds, List<String> queries)
+            throws IOException {
+        if (queries == null || queries.size() != 1) {
+            throw new IllegalArgumentException(
+                    "Streaming reports support exactly one query; got "
+                            + (queries == null ? 0 : queries.size()));
+        }
+        return generateReportStream(chipIds, queries.get(0), null, null);
     }
 
     // --- AI Credential methods ---

--- a/src/main/java/com/datalathe/client/results/DatalatheStreamingResultSet.java
+++ b/src/main/java/com/datalathe/client/results/DatalatheStreamingResultSet.java
@@ -1,0 +1,622 @@
+package com.datalathe.client.results;
+
+import com.datalathe.client.DatalatheQueryException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Response;
+import okio.BufferedSource;
+
+import java.io.IOException;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A forward-only ({@link java.sql.ResultSet#TYPE_FORWARD_ONLY}) result set that
+ * lazily consumes an NDJSON stream from the engine's streaming report endpoint
+ * ({@code POST /lathe/report} with {@code "stream": true}).
+ *
+ * <p>Each call to {@link #next()} pulls and parses one or more frames from the
+ * underlying OkHttp {@link BufferedSource} until a row is available, the stream
+ * ends, or a terminal {@code error} frame arrives. Backward navigation
+ * ({@code previous}, {@code first}, {@code last}, {@code absolute},
+ * {@code beforeFirst}, {@code relative} to a prior row) throws
+ * {@link SQLFeatureNotSupportedException}.</p>
+ *
+ * <p>Closing the result set closes the HTTP response body, which aborts the
+ * server-side stream. The instance is {@link AutoCloseable}, so it works in a
+ * try-with-resources block.</p>
+ */
+public class DatalatheStreamingResultSet extends AbstractResultSet {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Response response;
+    private final BufferedSource source;
+
+    private List<Schema> schema;
+    private String transformedQuery;
+
+    private List<List<String>> buffer = new ArrayList<>();
+    private int bufferIndex = 0;
+    private List<String> currentRow;
+
+    private boolean schemaSeen = false;
+    private boolean terminated = false;
+    private boolean closed = false;
+    private boolean wasNull = false;
+
+    private long rowCount = -1;
+    private long emittedRows = 0;
+
+    public DatalatheStreamingResultSet(Response response) throws SQLException {
+        this.response = response;
+        if (response.body() == null) {
+            throw new SQLException("Streaming report response had no body");
+        }
+        this.source = response.body().source();
+        readUntilSchema();
+    }
+
+    /**
+     * The total row count reported by the terminal {@code end} frame. Returns
+     * {@code -1} until the stream has been fully consumed.
+     */
+    public long getRowCount() {
+        return rowCount;
+    }
+
+    /**
+     * The query as transformed for the engine, when {@code returnTransformedQuery}
+     * was requested; otherwise {@code null}.
+     */
+    public String getTransformedQuery() {
+        return transformedQuery;
+    }
+
+    private void readUntilSchema() throws SQLException {
+        while (!schemaSeen) {
+            JsonNode frame = readFrame();
+            if (frame == null) {
+                throw new SQLException(
+                        "Streaming report ended before a schema frame was received");
+            }
+            handleFrame(frame);
+        }
+    }
+
+    private JsonNode readFrame() throws SQLException {
+        try {
+            String line = source.readUtf8Line();
+            while (line != null && line.isEmpty()) {
+                line = source.readUtf8Line();
+            }
+            if (line == null) {
+                return null;
+            }
+            return MAPPER.readTree(line);
+        } catch (IOException e) {
+            throw new SQLException("Failed to read streaming report frame", e);
+        }
+    }
+
+    private void handleFrame(JsonNode frame) throws SQLException {
+        JsonNode typeNode = frame.get("type");
+        String type = typeNode != null ? typeNode.asText() : null;
+        if (type == null) {
+            throw new SQLException("Streaming report frame missing \"type\": " + frame);
+        }
+        switch (type) {
+            case "schema":
+                handleSchema(frame);
+                break;
+            case "rows":
+                handleRows(frame);
+                break;
+            case "end":
+                handleEnd(frame);
+                break;
+            case "error":
+                handleError(frame);
+                break;
+            default:
+                throw new SQLException("Unknown streaming report frame type: " + type);
+        }
+    }
+
+    private void handleSchema(JsonNode frame) throws SQLException {
+        if (schemaSeen) {
+            throw new SQLException("Streaming report sent a second schema frame");
+        }
+        List<Schema> parsed = new ArrayList<>();
+        JsonNode schemaNode = frame.get("schema");
+        if (schemaNode != null && schemaNode.isArray()) {
+            for (JsonNode col : schemaNode) {
+                JsonNode nameNode = col.get("name");
+                JsonNode typeNode = col.get("data_type");
+                parsed.add(new Schema(
+                        nameNode != null ? nameNode.asText() : null,
+                        typeNode != null ? typeNode.asText() : null));
+            }
+        }
+        this.schema = Collections.unmodifiableList(parsed);
+        JsonNode tq = frame.get("transformed_query");
+        if (tq != null && !tq.isNull()) {
+            this.transformedQuery = tq.asText();
+        }
+        this.schemaSeen = true;
+    }
+
+    private void handleRows(JsonNode frame) throws SQLException {
+        List<List<String>> batch = new ArrayList<>();
+        JsonNode rowsNode = frame.get("rows");
+        if (rowsNode != null && rowsNode.isArray()) {
+            for (JsonNode rowNode : rowsNode) {
+                List<String> row = new ArrayList<>();
+                for (JsonNode cell : rowNode) {
+                    row.add(cell.isNull() ? null : cell.asText());
+                }
+                batch.add(row);
+            }
+        }
+        this.buffer = batch;
+        this.bufferIndex = 0;
+    }
+
+    private void handleEnd(JsonNode frame) {
+        JsonNode rc = frame.get("row_count");
+        if (rc != null && rc.isNumber()) {
+            this.rowCount = rc.asLong();
+        }
+        this.terminated = true;
+    }
+
+    private void handleError(JsonNode frame) throws SQLException {
+        this.terminated = true;
+        JsonNode errNode = frame.get("error");
+        String message = errNode != null ? errNode.asText() : "unknown streaming error";
+        closeQuietly();
+        throw new SQLException(new DatalatheQueryException(
+                Collections.singletonMap(0, message)));
+    }
+
+    @Override
+    public boolean next() throws SQLException {
+        if (closed) {
+            throw new SQLException("Result set is closed");
+        }
+        while (true) {
+            if (bufferIndex < buffer.size()) {
+                currentRow = buffer.get(bufferIndex++);
+                emittedRows++;
+                return true;
+            }
+            if (terminated) {
+                currentRow = null;
+                return false;
+            }
+            JsonNode frame = readFrame();
+            if (frame == null) {
+                terminated = true;
+                currentRow = null;
+                closeQuietly();
+                throw new SQLException(
+                        "Streaming report ended without a terminal frame "
+                                + "(transport failure after " + emittedRows + " rows)");
+            }
+            handleFrame(frame);
+        }
+    }
+
+    @Override
+    public void close() throws SQLException {
+        if (!closed) {
+            closed = true;
+            response.close();
+        }
+    }
+
+    private void closeQuietly() {
+        if (!closed) {
+            closed = true;
+            try {
+                response.close();
+            } catch (RuntimeException ignored) {
+                // best effort
+            }
+        }
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return closed;
+    }
+
+    @Override
+    public int getType() throws SQLException {
+        return TYPE_FORWARD_ONLY;
+    }
+
+    @Override
+    public int getConcurrency() throws SQLException {
+        return CONCUR_READ_ONLY;
+    }
+
+    @Override
+    public boolean wasNull() throws SQLException {
+        return wasNull;
+    }
+
+    // --- Accessors ---
+
+    private String getValue(int columnIndex) throws SQLException {
+        if (currentRow == null) {
+            throw new SQLException("No current row");
+        }
+        if (columnIndex < 1 || columnIndex > schema.size()) {
+            throw new SQLException("Invalid column index: " + columnIndex);
+        }
+        String value = currentRow.get(columnIndex - 1);
+        if (value != null && value.isEmpty()) {
+            return null;
+        }
+        return value;
+    }
+
+    @Override
+    public String getString(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        return value;
+    }
+
+    @Override
+    public boolean getBoolean(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        return value != null && Boolean.parseBoolean(value);
+    }
+
+    @Override
+    public byte getByte(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        return value == null ? 0 : Byte.parseByte(value);
+    }
+
+    @Override
+    public short getShort(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        return value == null ? 0 : Short.parseShort(value);
+    }
+
+    @Override
+    public int getInt(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        if (value == null) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return (int) Double.parseDouble(value);
+        }
+    }
+
+    @Override
+    public long getLong(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        return value == null ? 0L : Long.parseLong(value);
+    }
+
+    @Override
+    public float getFloat(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        return value == null ? 0.0f : Float.parseFloat(value);
+    }
+
+    @Override
+    public double getDouble(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        return value == null ? 0.0 : Double.parseDouble(value);
+    }
+
+    @Override
+    public Object getObject(int columnIndex) throws SQLException {
+        String value = getValue(columnIndex);
+        wasNull = value == null;
+        if (value == null) {
+            return null;
+        }
+        String dataType = schema.get(columnIndex - 1).getDataType();
+        try {
+            switch (dataType) {
+                case "Int32":
+                    return Integer.parseInt(value);
+                case "Int64":
+                    return Long.parseLong(value);
+                case "Float32":
+                    return Float.parseFloat(value);
+                case "Float64":
+                    return Double.parseDouble(value);
+                case "Boolean":
+                    return Boolean.parseBoolean(value);
+                default:
+                    return value;
+            }
+        } catch (NumberFormatException e) {
+            throw new SQLException("Cannot convert value to requested type: " + dataType, e);
+        }
+    }
+
+    @Override
+    public String getString(String columnLabel) throws SQLException {
+        return getString(findColumn(columnLabel));
+    }
+
+    @Override
+    public boolean getBoolean(String columnLabel) throws SQLException {
+        return getBoolean(findColumn(columnLabel));
+    }
+
+    @Override
+    public byte getByte(String columnLabel) throws SQLException {
+        return getByte(findColumn(columnLabel));
+    }
+
+    @Override
+    public short getShort(String columnLabel) throws SQLException {
+        return getShort(findColumn(columnLabel));
+    }
+
+    @Override
+    public int getInt(String columnLabel) throws SQLException {
+        return getInt(findColumn(columnLabel));
+    }
+
+    @Override
+    public long getLong(String columnLabel) throws SQLException {
+        return getLong(findColumn(columnLabel));
+    }
+
+    @Override
+    public float getFloat(String columnLabel) throws SQLException {
+        return getFloat(findColumn(columnLabel));
+    }
+
+    @Override
+    public double getDouble(String columnLabel) throws SQLException {
+        return getDouble(findColumn(columnLabel));
+    }
+
+    @Override
+    public Object getObject(String columnLabel) throws SQLException {
+        return getObject(findColumn(columnLabel));
+    }
+
+    @Override
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+        Object value = getObject(columnIndex);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return type.cast(value);
+        } catch (ClassCastException e) {
+            throw new SQLException("Cannot convert value to requested type: " + type.getName(), e);
+        }
+    }
+
+    @Override
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+        return getObject(findColumn(columnLabel), type);
+    }
+
+    @Override
+    public int findColumn(String columnLabel) throws SQLException {
+        for (int i = 0; i < schema.size(); i++) {
+            if (schema.get(i).getName().equalsIgnoreCase(columnLabel)) {
+                return i + 1;
+            }
+        }
+        throw new SQLException("Column not found: " + columnLabel);
+    }
+
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
+        return new ResultSetMetaData() {
+            @Override
+            public int getColumnCount() {
+                return schema.size();
+            }
+
+            @Override
+            public boolean isAutoIncrement(int column) {
+                return false;
+            }
+
+            @Override
+            public boolean isCaseSensitive(int column) {
+                return true;
+            }
+
+            @Override
+            public boolean isSearchable(int column) {
+                return true;
+            }
+
+            @Override
+            public boolean isCurrency(int column) {
+                return false;
+            }
+
+            @Override
+            public int isNullable(int column) {
+                return columnNullable;
+            }
+
+            @Override
+            public boolean isSigned(int column) {
+                return true;
+            }
+
+            @Override
+            public int getColumnDisplaySize(int column) {
+                return 0;
+            }
+
+            @Override
+            public String getColumnLabel(int column) throws SQLException {
+                return getColumnName(column);
+            }
+
+            @Override
+            public String getColumnName(int column) {
+                return schema.get(column - 1).getName();
+            }
+
+            @Override
+            public String getSchemaName(int column) {
+                return "";
+            }
+
+            @Override
+            public int getPrecision(int column) {
+                return 0;
+            }
+
+            @Override
+            public int getScale(int column) {
+                return 0;
+            }
+
+            @Override
+            public String getTableName(int column) {
+                return "";
+            }
+
+            @Override
+            public String getCatalogName(int column) {
+                return "";
+            }
+
+            @Override
+            public int getColumnType(int column) {
+                String dataType = schema.get(column - 1).getDataType();
+                switch (dataType) {
+                    case "Int32":
+                    case "Int64":
+                        return Types.INTEGER;
+                    case "Float32":
+                    case "Float64":
+                        return Types.DOUBLE;
+                    case "Boolean":
+                        return Types.BOOLEAN;
+                    default:
+                        return Types.VARCHAR;
+                }
+            }
+
+            @Override
+            public String getColumnTypeName(int column) {
+                return schema.get(column - 1).getDataType();
+            }
+
+            @Override
+            public boolean isReadOnly(int column) {
+                return true;
+            }
+
+            @Override
+            public boolean isWritable(int column) {
+                return false;
+            }
+
+            @Override
+            public boolean isDefinitelyWritable(int column) {
+                return false;
+            }
+
+            @Override
+            public String getColumnClassName(int column) {
+                String dataType = schema.get(column - 1).getDataType();
+                switch (dataType) {
+                    case "Int32":
+                        return Integer.class.getName();
+                    case "Int64":
+                        return Long.class.getName();
+                    case "Float32":
+                        return Float.class.getName();
+                    case "Float64":
+                        return Double.class.getName();
+                    case "Boolean":
+                        return Boolean.class.getName();
+                    default:
+                        return String.class.getName();
+                }
+            }
+
+            @Override
+            public <T> T unwrap(Class<T> iface) throws SQLException {
+                throw new SQLFeatureNotSupportedException();
+            }
+
+            @Override
+            public boolean isWrapperFor(Class<?> iface) {
+                return false;
+            }
+        };
+    }
+
+    // --- Forward-only: backward navigation is unsupported ---
+
+    @Override
+    public boolean previous() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "Streaming result sets are forward-only");
+    }
+
+    @Override
+    public boolean first() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "Streaming result sets are forward-only");
+    }
+
+    @Override
+    public boolean last() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "Streaming result sets are forward-only");
+    }
+
+    @Override
+    public boolean absolute(int row) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "Streaming result sets are forward-only");
+    }
+
+    @Override
+    public boolean relative(int rows) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "Streaming result sets are forward-only");
+    }
+
+    @Override
+    public void beforeFirst() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "Streaming result sets are forward-only");
+    }
+
+    @Override
+    public void afterLast() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "Streaming result sets are forward-only");
+    }
+}

--- a/src/main/java/com/datalathe/client/types/GenerateReportRequest.java
+++ b/src/main/java/com/datalathe/client/types/GenerateReportRequest.java
@@ -32,6 +32,10 @@ public class GenerateReportRequest {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean returnTransformedQuery;
 
+    @JsonProperty("stream")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean stream;
+
     public GenerateReportRequest(List<String> chipIds, SourceType sourceType, Queries queryRequest) {
         this.chipIds = chipIds;
         this.sourceType = sourceType;

--- a/src/test/java/com/datalathe/client/DatalatheStreamingResultSetTest.java
+++ b/src/test/java/com/datalathe/client/DatalatheStreamingResultSetTest.java
@@ -1,0 +1,232 @@
+package com.datalathe.client;
+
+import com.datalathe.client.results.DatalatheStreamingResultSet;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DatalatheStreamingResultSetTest {
+    private MockWebServer server;
+    private DatalatheClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        client = new DatalatheClient(server.url("/").toString());
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    private static MockResponse ndjson(String body) {
+        return new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/x-ndjson")
+                .setBody(body);
+    }
+
+    @Test
+    void happyPathSchemaTwoBatchesEnd() throws Exception {
+        String body = String.join("\n",
+                "{\"type\":\"schema\",\"schema\":[{\"name\":\"id\",\"data_type\":\"Int32\"},"
+                        + "{\"name\":\"name\",\"data_type\":\"Utf8\"}]}",
+                "{\"type\":\"rows\",\"rows\":[[\"1\",\"alice\"],[\"2\",\"bob\"]]}",
+                "{\"type\":\"rows\",\"rows\":[[\"3\",\"carol\"]]}",
+                "{\"type\":\"end\",\"row_count\":3,\"timing\":{\"total_ms\":10}}") + "\n";
+        server.enqueue(ndjson(body));
+
+        int count = 0;
+        try (DatalatheStreamingResultSet rs = client.generateReportStream(
+                Arrays.asList("chip1"), "SELECT id, name FROM t")) {
+
+            ResultSetMetaData md = rs.getMetaData();
+            assertEquals(2, md.getColumnCount());
+            assertEquals("id", md.getColumnName(1));
+            assertEquals("name", md.getColumnName(2));
+
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertEquals("alice", rs.getString(2));
+            assertEquals("alice", rs.getString("name"));
+            count++;
+
+            assertTrue(rs.next());
+            assertEquals(2, rs.getInt("id"));
+            assertEquals("bob", rs.getString(2));
+            count++;
+
+            assertTrue(rs.next());
+            assertEquals(3, rs.getInt(1));
+            assertEquals("carol", rs.getString(2));
+            count++;
+
+            assertFalse(rs.next());
+            assertEquals(3, count);
+            assertEquals(3L, rs.getRowCount());
+        }
+
+        RecordedRequest req = server.takeRequest();
+        assertTrue(req.getPath().endsWith("/lathe/report"));
+        String sent = req.getBody().readUtf8();
+        assertTrue(sent.contains("\"stream\":true"), "stream flag must be set");
+        assertTrue(sent.contains("\"query\":[\"SELECT id, name FROM t\"]"));
+    }
+
+    @Test
+    void forwardOnlyMethodsThrow() throws Exception {
+        String body = String.join("\n",
+                "{\"type\":\"schema\",\"schema\":[{\"name\":\"id\",\"data_type\":\"Int32\"}]}",
+                "{\"type\":\"rows\",\"rows\":[[\"1\"]]}",
+                "{\"type\":\"end\",\"row_count\":1}") + "\n";
+        server.enqueue(ndjson(body));
+
+        try (DatalatheStreamingResultSet rs = client.generateReportStream(
+                Arrays.asList("chip1"), "SELECT id FROM t")) {
+            assertThrows(SQLFeatureNotSupportedException.class, rs::previous);
+            assertThrows(SQLFeatureNotSupportedException.class, rs::first);
+            assertThrows(SQLFeatureNotSupportedException.class, rs::last);
+            assertThrows(SQLFeatureNotSupportedException.class, () -> rs.absolute(1));
+            assertThrows(SQLFeatureNotSupportedException.class, () -> rs.relative(1));
+            assertThrows(SQLFeatureNotSupportedException.class, rs::beforeFirst);
+            assertThrows(SQLFeatureNotSupportedException.class, rs::afterLast);
+        }
+    }
+
+    @Test
+    void multiQueryRejectedClientSide() {
+        List<String> queries = Arrays.asList("SELECT 1", "SELECT 2");
+        assertThrows(IllegalArgumentException.class,
+                () -> client.generateReportStream(Arrays.asList("chip1"), queries));
+        // No request should have been issued.
+        assertEquals(0, server.getRequestCount());
+    }
+
+    @Test
+    void errorFrameThrowsFromNext() throws Exception {
+        String body = String.join("\n",
+                "{\"type\":\"schema\",\"schema\":[{\"name\":\"id\",\"data_type\":\"Int32\"}]}",
+                "{\"type\":\"rows\",\"rows\":[[\"1\"]]}",
+                "{\"type\":\"error\",\"error\":\"Cast error mid-scan\",\"error_code\":\"runtime\"}") + "\n";
+        server.enqueue(ndjson(body));
+
+        try (DatalatheStreamingResultSet rs = client.generateReportStream(
+                Arrays.asList("chip1"), "SELECT id FROM t")) {
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+
+            SQLException ex = assertThrows(SQLException.class, rs::next);
+            Throwable cause = ex.getCause();
+            assertTrue(cause instanceof DatalatheQueryException,
+                    "error frame must wrap DatalatheQueryException");
+            assertTrue(ex.getMessage().contains("Cast error mid-scan"));
+        }
+    }
+
+    @Test
+    void truncatedStreamThrows() throws Exception {
+        // Schema + rows but no terminal end/error frame: transport failure.
+        String body = String.join("\n",
+                "{\"type\":\"schema\",\"schema\":[{\"name\":\"id\",\"data_type\":\"Int32\"}]}",
+                "{\"type\":\"rows\",\"rows\":[[\"1\"]]}") + "\n";
+        server.enqueue(ndjson(body));
+
+        try (DatalatheStreamingResultSet rs = client.generateReportStream(
+                Arrays.asList("chip1"), "SELECT id FROM t")) {
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+
+            SQLException ex = assertThrows(SQLException.class, rs::next);
+            assertTrue(ex.getMessage().toLowerCase().contains("terminal"),
+                    "truncated stream message should mention the missing terminal frame");
+        }
+    }
+
+    @Test
+    void emptyResult() throws Exception {
+        String body = String.join("\n",
+                "{\"type\":\"schema\",\"schema\":[{\"name\":\"id\",\"data_type\":\"Int32\"}]}",
+                "{\"type\":\"end\",\"row_count\":0}") + "\n";
+        server.enqueue(ndjson(body));
+
+        try (DatalatheStreamingResultSet rs = client.generateReportStream(
+                Arrays.asList("chip1"), "SELECT id FROM t WHERE 1=0")) {
+            assertEquals(1, rs.getMetaData().getColumnCount());
+            assertFalse(rs.next());
+            assertEquals(0L, rs.getRowCount());
+        }
+    }
+
+    @Test
+    void wasNullOnNullCells() throws Exception {
+        String body = String.join("\n",
+                "{\"type\":\"schema\",\"schema\":[{\"name\":\"id\",\"data_type\":\"Int32\"},"
+                        + "{\"name\":\"name\",\"data_type\":\"Utf8\"}]}",
+                "{\"type\":\"rows\",\"rows\":[[\"1\",null],[null,\"bob\"]]}",
+                "{\"type\":\"end\",\"row_count\":2}") + "\n";
+        server.enqueue(ndjson(body));
+
+        try (DatalatheStreamingResultSet rs = client.generateReportStream(
+                Arrays.asList("chip1"), "SELECT id, name FROM t")) {
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertFalse(rs.wasNull());
+            assertNull(rs.getString(2));
+            assertTrue(rs.wasNull());
+
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt(1));
+            assertTrue(rs.wasNull());
+            assertEquals("bob", rs.getString(2));
+            assertFalse(rs.wasNull());
+
+            assertFalse(rs.next());
+        }
+    }
+
+    @Test
+    void requestErrorBeforeStreamThrowsChipNotFound() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"error\":\"Chip 'lost' is not available\","
+                        + "\"error_code\":\"chip_not_found\",\"chip_id\":\"lost\"}"));
+
+        ChipNotFoundException ex = assertThrows(ChipNotFoundException.class,
+                () -> client.generateReportStream(Arrays.asList("lost"), "SELECT 1"));
+        assertEquals("lost", ex.getChipId());
+    }
+
+    @Test
+    void transformedQueryExposedFromSchemaFrame() throws Exception {
+        String body = String.join("\n",
+                "{\"type\":\"schema\",\"schema\":[{\"name\":\"n\",\"data_type\":\"Utf8\"}],"
+                        + "\"transformed_query\":\"SELECT COALESCE(n,'x') FROM t\"}",
+                "{\"type\":\"rows\",\"rows\":[[\"a\"]]}",
+                "{\"type\":\"end\",\"row_count\":1}") + "\n";
+        server.enqueue(ndjson(body));
+
+        try (DatalatheStreamingResultSet rs = client.generateReportStream(
+                Arrays.asList("chip1"), "SELECT IFNULL(n,'x') FROM t", true, true)) {
+            assertEquals("SELECT COALESCE(n,'x') FROM t", rs.getTransformedQuery());
+            assertTrue(rs.next());
+            assertEquals("a", rs.getString(1));
+            assertFalse(rs.next());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds streaming consumption of the engine's NDJSON report response. **Hold for the 1.8 engine release** — the streaming endpoint this calls only exists on engine 1.8+.

- `generateReportStream(...)` — sets `stream: true`, single-query only (rejects multiple client-side), `Accept: application/x-ndjson`
- `DatalatheStreamingResultSet extends AbstractResultSet` — JDBC `TYPE_FORWARD_ONLY`; `next()` lazily reads frames from the OkHttp `BufferedSource`; typed accessors by 1-based index + label; `wasNull()`; `getMetaData()` from the schema frame; backward navigation throws `SQLFeatureNotSupportedException`; `close()` closes the response body (aborts the server stream)
- Error frame → `SQLException` wrapping `DatalatheQueryException`; truncated stream → `SQLException` — never presents a partial result as complete

## Test plan
- [x] 9 streaming tests incl. truncated-stream throws, error-frame throws, forward-only throws, multi-query rejected, wasNull, chip-not-found before stream
- [x] `mvn test` 72 passed
- [ ] Merge + publish (CI on tag) with the 1.8 engine release