### PR TITLE
Release 1.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>


### PR DESCRIPTION
## Summary
Version-only bump 1.8.0 → 1.8.1. **No code change.**

The 1.8.0 Maven Central deployment (`c48487ad`) is stuck in PUBLISHING on Sonatype's side — validated 1/1 but hung for days, holding the `com.datalathe:datalathe-client:1.8.0` coordinate so it can't be re-pushed or dropped. This republishes the identical streaming-results client (`generateReportStream` / `DatalatheStreamingResultSet`) under 1.8.1 so JVM consumers have a pullable artifact while Sonatype clears the stuck 1.8.0 deployment.

## Test plan
- [ ] CI green (no code change)
- [ ] Tag v1.8.1 → publish.yml uploads to Maven Central (fresh coordinate, no conflict) → propagates to repo1