### PR TITLE
Tolerate unknown fields when deserializing responses

### DIFF
--- a/src/main/java/com/datalathe/client/DatalatheClient.java
+++ b/src/main/java/com/datalathe/client/DatalatheClient.java
@@ -2,6 +2,7 @@ package com.datalathe.client;
 
 import com.datalathe.client.results.DatalatheStreamingResultSet;
 import com.datalathe.client.types.*;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.*;
@@ -20,7 +21,8 @@ public class DatalatheClient {
     private final String baseUrl;
     private final Map<String, String> defaultHeaders;
     private final OkHttpClient client;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
     /**

--- a/src/test/java/com/datalathe/client/TolerantDeserializationTest.java
+++ b/src/test/java/com/datalathe/client/TolerantDeserializationTest.java
@@ -1,0 +1,53 @@
+package com.datalathe.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datalathe.client.types.GenerateReportResponse;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+
+class TolerantDeserializationTest {
+
+    @Test
+    void createChipToleratesUnknownResponseFields() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200).setBody(
+                    "{\"chip_id\":\"chip-123\",\"some_future_field\":\"x\",\"another_new_one\":true}"));
+            server.start();
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+
+            String chipId = client.createChip("src", "SELECT 1", "t");
+
+            assertEquals("chip-123", chipId);
+        }
+    }
+
+    @Test
+    void generateReportToleratesUnknownResponseFields() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200).setBody(
+                    "{\"result\":{\"0\":{\"data\":[[\"1\"]],\"future_nested\":\"y\"}},"
+                    + "\"timing\":{\"total_ms\":5,\"chip_attach_ms\":1,"
+                    + "\"query_execution_ms\":4,\"future_timing_field\":9},"
+                    + "\"some_future_top_field\":\"z\"}"));
+            server.start();
+            DatalatheClient client = new DatalatheClient(
+                    server.url("/").toString().replaceAll("/$", ""));
+
+            GenerateReportResult report = client.generateReport(
+                    List.of("chip-123"), List.of("SELECT 1"), null, null, true);
+
+            assertNotNull(report);
+            GenerateReportResponse.Result result = report.getResults().get(0);
+            assertNotNull(result);
+            assertEquals(List.of(List.of("1")), result.getData());
+            assertEquals(5L, report.getTiming().getTotalMs());
+            assertTrue(report.getResults().containsKey(0));
+        }
+    }
+}


### PR DESCRIPTION
## What

Configures the client's shared ObjectMapper with `FAIL_ON_UNKNOWN_PROPERTIES` disabled, so additive server response fields no longer throw `UnrecognizedPropertyException`. All response DTO binding funnels through this one mapper (`parseBody`); the two other mappers in the codebase only handle collections/`JsonNode` and are unaffected.

## Why

An engine deploy that added an optional response field broke strict deserialization in the field (`Unrecognized field "total_rows" (class CreateChipResponse)`). An SDK should tolerate additive fields from newer servers.

## Tests

TDD: two regression tests drive the real client against MockWebServer with unknown fields at top level and nested (`CreateChipResponse`, `GenerateReportResponse`); red-first with the strict mapper, green after. Full suite: 74 passed, 0 failures.
