### PR TITLE
Release 1.8.2: tolerant response deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The library is published to [Maven Central](https://central.sonatype.com/artifac
 <dependency>
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.datalathe</groupId>
     <artifactId>datalathe-client</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <packaging>jar</packaging>
 
     <name>Datalathe Java Client</name>


### PR DESCRIPTION
Cuts 1.8.2 (patch): unknown fields in server responses no longer break deserialization (#58) — future additive engine response fields (like 1.8.1's streaming ingest metadata) can't fault older clients. Also picks up the README usage fix (#60) and dependency bumps (Jackson 2.22.0, publish plugin, setup-java).

Tag v1.8.2 on the merge commit publishes to Maven Central via the tag workflow.